### PR TITLE
SQSMessage fromJson fix and message filtration

### DIFF
--- a/manager/src/main/scala/io/hydrosphere/serving/manager/actor/modelsource/S3SourceWatcher.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/actor/modelsource/S3SourceWatcher.scala
@@ -23,6 +23,8 @@ class S3SourceWatcher(val source: S3ModelSource) extends SourceWatcher {
       .getMessages
     val msgBodies = messages.map(m => m -> m.getBody)
       .map { case (m, b) => m -> SQSMessage.fromJson(b) }
+      .filter { case (_, opt) => opt.isDefined }
+      .map { case (m, opt) => m -> opt.get }
       .filter { case (_, b) => b.bucket == source.configuration.bucket }
       .toMap
 
@@ -32,7 +34,7 @@ class S3SourceWatcher(val source: S3ModelSource) extends SourceWatcher {
           case "ObjectRemoved" =>
             log.debug(s"ObjectRemoved: ${info.objKey}")
             if (info.objKey.endsWith("/")) {
-              val files = source.cacheSource.getAllFiles(info.objKey).map{ f =>
+              val files = source.cacheSource.getAllFiles(info.objKey).map { f =>
                 new FileDeleted(source, info.objKey + f, Instant.now())
               }
               source.deleteProxyObject(info.objKey)
@@ -44,7 +46,7 @@ class S3SourceWatcher(val source: S3ModelSource) extends SourceWatcher {
           case "ObjectCreated" =>
             log.debug(s"ObjectCreated: ${info.objKey}")
             if (info.objKey.endsWith("/")) {
-              source.getAllFiles(info.objKey).map{ f =>
+              source.getAllFiles(info.objKey).map { f =>
                 val fullpath = info.objKey + f
                 source.deleteProxyObject(fullpath)
                 val file = source.downloadObject(fullpath)
@@ -76,21 +78,22 @@ object S3SourceWatcher{
   object SQSMessage extends CommonJsonSupport {
     import spray.json._
 
-    def fromJson(json: String): SQSMessage = {
+    def fromJson(json: String): Option[SQSMessage] = {
       val map = json.parseJson.convertTo[Map[String, Any]]
-      val record = map("Records").asInstanceOf[List[Map[String, Any]]].head
-      val s3Data = record("s3").asInstanceOf[Map[String, Any]]
-      val bucketData = s3Data("bucket").asInstanceOf[Map[String, Any]]
-      val bucketName = bucketData("name").asInstanceOf[String]
-      val objectData = s3Data("object").asInstanceOf[Map[String, Any]]
-      val objKey = objectData("key").asInstanceOf[String]
+      map.get("Records").map{ records =>
+        val record = records.asInstanceOf[List[Map[String, Any]]].head
+        val s3Data = record("s3").asInstanceOf[Map[String, Any]]
+        val bucketData = s3Data("bucket").asInstanceOf[Map[String, Any]]
+        val bucketName = bucketData("name").asInstanceOf[String]
+        val objectData = s3Data("object").asInstanceOf[Map[String, Any]]
+        val objKey = objectData("key").asInstanceOf[String]
 
-      val eventName = record("eventName").asInstanceOf[String]
-      val eventTimeStr = record("eventTime").asInstanceOf[String]
-      val eventTime = LocalDateTime.ofInstant(Instant.parse(eventTimeStr), ZoneId.systemDefault())
-      SQSMessage(bucketName, objKey, eventName, eventTime)
+        val eventName = record("eventName").asInstanceOf[String]
+        val eventTimeStr = record("eventTime").asInstanceOf[String]
+        val eventTime = LocalDateTime.ofInstant(Instant.parse(eventTimeStr), ZoneId.systemDefault())
+        SQSMessage(bucketName, objKey, eventName, eventTime)
+      }
     }
-
   }
 
   def props(source: S3ModelSource)=

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/SQSMessageSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/SQSMessageSpec.scala
@@ -1,0 +1,70 @@
+package io.hydrosphere.serving.manager
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+
+import io.hydrosphere.serving.manager.actor.modelsource.S3SourceWatcher.SQSMessage
+import org.scalatest.WordSpec
+
+class SQSMessageSpec extends WordSpec {
+  val be = afterWord("be")
+
+  "SQSMessage" when {
+    "correct S3 event message" should be {
+      "defined" in {
+        val time = Instant.now()
+        val inMsg =
+          s"""
+            |{
+            | "Records": [
+            |  {
+            |   "eventName": "TEST_EVENT",
+            |   "eventTime": "${time.toString}",
+            |   "s3": {
+            |     "bucket": {
+            |       "name" : "test_bucket"
+            |     },
+            |     "object": {
+            |       "key": "test_object"
+            |     }
+            |   }
+            |  }
+            | ]
+            |}
+            |
+          """.stripMargin
+        val sqsMsg = SQSMessage.fromJson(inMsg)
+        assert(sqsMsg.isDefined)
+        val msg = sqsMsg.get
+        assert(msg.bucket === "test_bucket")
+        assert(msg.objKey === "test_object")
+        assert(msg.eventTime === LocalDateTime.ofInstant(time, ZoneId.systemDefault()))
+        assert(msg.eventName === "TEST_EVENT")
+      }
+    }
+    "other event message" should be {
+      "None" in {
+        val inMsg =
+          s"""
+             |{
+             | "ServiceMessage": [
+             |  {
+             |   "eventName": "TEST_EVENT",
+             |   "s3": {
+             |     "bucket": {
+             |       "name" : "test_bucket"
+             |     },
+             |     "object": {
+             |       "key": "test_object"
+             |     }
+             |   }
+             |  }
+             | ]
+             |}
+             |
+          """.stripMargin
+        val sqsMsg = SQSMessage.fromJson(inMsg)
+        assert(sqsMsg.isEmpty)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Non-S3 messages have a different structure that S3 event messages, and in some circumstances can cause a crash of the manager (e.g. #36 ).

This PR fixes this issue.