### PR TITLE
Next version availability reimplementation

### DIFF
--- a/common/src/main/scala/io/hydrosphere/serving/model/models.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model/models.scala
@@ -29,7 +29,9 @@ case class ModelRuntime(
   modelId: Option[Long],
   configParams: Map[String, String],
   tags: List[String]
-)
+) {
+  def toImageDef: String = s"$imageName:$imageTag"
+}
 
 case class ServingEnvironment(
   id: Long,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - "8080:8080"
       - "8082:8082"
-      - "9090:9090"
+      - "9090:9090" # HTTP API
+      - "9091:9091" # GRPC API
     depends_on:
       - postgres
       - zipkin
@@ -32,4 +33,4 @@ services:
       ZIPKIN_ENABLED: "true"
       ZIPKIN_HOST: "zipkin"
       LOCAL_MODEL_PATH: "/models"
-      DOCKER_NETWORK_NAME: "hydroserving_default"
+      NETWORK_NAME: "hydroserving_default"

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/controller/RuntimeTypeController.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/controller/RuntimeTypeController.scala
@@ -28,8 +28,6 @@ class RuntimeTypeController(modelManagementService: ModelManagementService, runt
   ))
   def listRuntimeType = path("api" / "v1" / "runtimeType") {
     get {
-      println("123KEK123")
-
       complete(modelManagementService.allRuntimeTypes())
     }
   }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/controller/ui/UIJsonSupport.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/controller/ui/UIJsonSupport.scala
@@ -7,7 +7,7 @@ import io.hydrosphere.serving.manager.service._
   *
   */
 trait UIJsonSupport extends ManagerJsonSupport {
-  implicit val modelInfoFormat = jsonFormat6(ModelInfo)
+  implicit val modelInfoFormat = jsonFormat5(ModelInfo)
 
   implicit val kafkaStreamingParamsFormat = jsonFormat4(KafkaStreamingParams)
   implicit val serviceWeightDetailsFormat = jsonFormat2(ServiceWeightDetails)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/DockerRuntimeDeployService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/DockerRuntimeDeployService.scala
@@ -54,7 +54,7 @@ class DockerRuntimeDeployService(
         .logConfig(logConfig)
         .networkMode(conf.networkName).build()
       )
-      .image(s"${runtime.modelRuntime.imageName}:${runtime.modelRuntime.imageMD5Tag}")
+      .image(runtime.modelRuntime.toImageDef)
       .labels(javaLabels)
       .env(envMap.map { case (k, v) => s"$k=$v" }.toList)
       .build(), runtime.serviceName)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/EcsRuntimeDeployService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/EcsRuntimeDeployService.scala
@@ -65,8 +65,8 @@ class EcsRuntimeDeployService(
     )
 
     val containerDefinition = new ContainerDefinition()
-      .withName(formatServiceName(s"${runtime.serviceName}"))
-      .withImage(s"${runtime.modelRuntime.imageName}:${runtime.modelRuntime.imageTag}")
+      .withName(formatServiceName(runtime.serviceName))
+      .withImage(runtime.modelRuntime.toImageDef)
       .withMemoryReservation(500)
       .withEnvironment(env)
       .withDockerLabels(labels)
@@ -84,7 +84,7 @@ class EcsRuntimeDeployService(
     })
 
     val registerTaskDefinition = new RegisterTaskDefinitionRequest()
-      .withFamily(formatServiceName(s"${runtime.serviceName}"))
+      .withFamily(formatServiceName(runtime.serviceName))
       .withNetworkMode(NetworkMode.Bridge)
       .withContainerDefinitions(
         containerDefinition

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/SwarmRuntimeDeployService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/clouddriver/SwarmRuntimeDeployService.scala
@@ -56,7 +56,7 @@ class SwarmRuntimeDeployService(
       .taskTemplate(
         TaskSpec.builder()
           .containerSpec(ContainerSpec.builder()
-            .image(s"${runtime.modelRuntime.imageName}:${runtime.modelRuntime.imageMD5Tag}")
+            .image(runtime.modelRuntime.toImageDef)
             .env(envMap.map { case (k, v) => s"$k=$v" }.toList)
             .labels(javaLabels)
             //.placement()


### PR DESCRIPTION
* Fixed false positive model updates detection (#52) 
* Optional `nextVersion` field for `/ui/v1/model` endpoint:
  * If a model is new or changed since last build, the field contains next model version
  * Otherwise, the field is omitted