### PR TITLE
API to edit model contract

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val common = project.in(file("common"))
   .settings(libraryDependencies ++= Dependencies.commonDependencies)
   .settings(
     libraryDependencies ++= Seq(
-      "io.hydrosphere" %% "serving-grpc-scala" % "0.0.8",
+      "io.hydrosphere" %% "serving-grpc-scala" % "0.0.11",
       "org.mockito" % "mockito-all" % "1.10.19" % "test",
       "org.scalactic" %% "scalactic" % Dependencies.scalaTestVersion % "test",
       "org.scalatest" %% "scalatest" % Dependencies.scalaTestVersion % "test"

--- a/common/src/main/scala/io/hydrosphere/serving/model/CommonJsonSupport.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model/CommonJsonSupport.scala
@@ -6,7 +6,7 @@ import java.time.format.DateTimeFormatter
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import io.hydrosphere.serving.contract.model_contract.ModelContract
 import io.hydrosphere.serving.tensorflow.types.DataType
-import io.hydrosphere.serving.model_api.ContractOps.{FieldDescription, SignatureDescription}
+import io.hydrosphere.serving.model_api.ContractOps.{ContractDescription, FieldDescription, SignatureDescription}
 import io.hydrosphere.serving.model_api.ModelType
 import org.apache.logging.log4j.scala.Logging
 import spray.json._
@@ -102,6 +102,7 @@ trait CommonJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with L
 
   implicit val fieldDescFormat = jsonFormat3(FieldDescription.apply)
   implicit val sigDescFormat = jsonFormat3(SignatureDescription.apply)
+  implicit val contractDescFormat = jsonFormat1(ContractDescription.apply)
 
   implicit val runtimeTypeFormat = jsonFormat6(RuntimeType)
   implicit val modelRuntimeFormat = jsonFormat13(ModelRuntime)

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/ContractOps.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/ContractOps.scala
@@ -143,8 +143,10 @@ object ContractOps {
   object Implicits {
 
     implicit class ModelContractPumped(modelContract: ModelContract) {
-      def flatten: List[SignatureDescription] = {
-        ModelContractOps.flatten(modelContract)
+      def flatten: ContractDescription = {
+        ContractDescription(
+          ModelContractOps.flatten(modelContract)
+        )
       }
     }
 

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/ContractOps.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/ContractOps.scala
@@ -17,11 +17,28 @@ import scala.collection.mutable
 
 object ContractOps {
 
+  case class ContractDescription(
+    signatures: List[SignatureDescription]
+  ) {
+    def toContract: ModelContract = ContractDescription.toContract(this)
+  }
+
+  object ContractDescription {
+    def toContract(contractDescription: ContractDescription): ModelContract = {
+      ModelContract(
+        modelName = "",
+        signatures = contractDescription.signatures.map(SignatureDescription.toSignature)
+      )
+    }
+  }
+
   case class SignatureDescription(
     signatureName: String,
     inputs: List[FieldDescription],
     outputs: List[FieldDescription]
-  )
+  ) {
+    def toSignature: ModelSignature = SignatureDescription.toSignature(this)
+  }
 
   object SignatureDescription {
     class Converter() {

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
@@ -20,35 +20,22 @@ object ModelContractBuilders {
     )
   }
 
-  def createTensorInfo(name: String, dataType: DataType, shape: Option[Seq[Long]]): TensorInfo = {
-    TensorInfo(name, dataType, shape.map(createTensorShape))
+  def createTensorInfo(dataType: DataType, shape: Option[Seq[Long]]): TensorInfo = {
+    TensorInfo(dataType, shape.map(createTensorShape))
   }
 
-  def dictField(name: String, map: Map[String, ModelField]): ModelField = {
+  def complexField(name: String, subFields: Seq[ModelField]): ModelField = {
     ModelField(
       name,
-      ModelField.InfoOrDict.Dict(
-        ModelField.Dict(
-          map
-        )
-      )
-    )
-  }
-
-  def flatDictField(name: String, map: Map[String, TensorInfo]): ModelField = {
-    ModelField(
-      name,
-      ModelField.InfoOrDict.Dict(
-        ModelField.Dict(
-          map.map{
-            case (key, value) =>  key -> createTensorModelField(value.name, value.dtype, value.tensorShape.map(_.toDimList))
-          }
+      ModelField.InfoOrSubfields.Subfields(
+        ModelField.ComplexField(
+          subFields
         )
       )
     )
   }
 
   def createTensorModelField(name: String, dataType: DataType, shape: Option[Seq[Long]]): ModelField = {
-    ModelField(name, ModelField.InfoOrDict.Info(createTensorInfo(name, dataType, shape)))
+    ModelField(name, ModelField.InfoOrSubfields.Info(createTensorInfo(dataType, shape)))
   }
 }

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
@@ -24,7 +24,18 @@ object ModelContractBuilders {
     TensorInfo(name, dataType, shape.map(createTensorShape))
   }
 
-  def createDictModelField(name: String, map: Map[String, TensorInfo]): ModelField = {
+  def dictField(name: String, map: Map[String, ModelField]): ModelField = {
+    ModelField(
+      name,
+      ModelField.InfoOrDict.Dict(
+        ModelField.Dict(
+          map
+        )
+      )
+    )
+  }
+
+  def flatDictField(name: String, map: Map[String, TensorInfo]): ModelField = {
     ModelField(
       name,
       ModelField.InfoOrDict.Dict(

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/ModelContractBuilders.scala
@@ -12,16 +12,17 @@ object ModelContractBuilders {
     TensorShapeProto(unknownRank = true)
   }
 
-  def createTensorShape(dims: Seq[Long]): TensorShapeProto = {
+  def createTensorShape(dims: Seq[Long], unknownRank: Boolean = false): TensorShapeProto = {
     TensorShapeProto(
-      dims.map { d =>
+      dim = dims.map { d =>
         TensorShapeProto.Dim(d)
-      }
+      },
+      unknownRank = unknownRank
     )
   }
 
-  def createTensorInfo(dataType: DataType, shape: Option[Seq[Long]]): TensorInfo = {
-    TensorInfo(dataType, shape.map(createTensorShape))
+  def createTensorInfo(dataType: DataType, shape: Option[Seq[Long]], unknownRank: Boolean = false): TensorInfo = {
+    TensorInfo(dataType, shape.map(s => createTensorShape(s, unknownRank)))
   }
 
   def complexField(name: String, subFields: Seq[ModelField]): ModelField = {
@@ -35,7 +36,11 @@ object ModelContractBuilders {
     )
   }
 
-  def createTensorModelField(name: String, dataType: DataType, shape: Option[Seq[Long]]): ModelField = {
-    ModelField(name, ModelField.InfoOrSubfields.Info(createTensorInfo(dataType, shape)))
+  def rawTensorModelField(name: String, dataType: DataType, shape: Option[TensorShapeProto]): ModelField = {
+    ModelField(name, ModelField.InfoOrSubfields.Info(TensorInfo(dataType, shape)))
+  }
+
+  def simpleTensorModelField(name: String, dataType: DataType, shape: Option[Seq[Long]], unknownRank: Boolean = false): ModelField = {
+    ModelField(name, ModelField.InfoOrSubfields.Info(createTensorInfo(dataType, shape, unknownRank)))
   }
 }

--- a/common/src/main/scala/io/hydrosphere/serving/model_api/SignatureChecker.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/model_api/SignatureChecker.scala
@@ -1,7 +1,7 @@
 package io.hydrosphere.serving.model_api
 
 import io.hydrosphere.serving.contract.model_field.ModelField
-import io.hydrosphere.serving.contract.model_field.ModelField.InfoOrDict.{Dict, Empty, Info}
+import io.hydrosphere.serving.contract.model_field.ModelField.InfoOrSubfields.{Empty, Info, Subfields}
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
 import io.hydrosphere.serving.tensorflow.tensor_info.TensorInfo
 import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
@@ -9,7 +9,7 @@ import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
 object SignatureChecker {
 
   def areCompatible(first: Seq[TensorShapeProto.Dim], second: Seq[TensorShapeProto.Dim]): Boolean = {
-    if (first.length != second.length) {
+    if (first.lengthCompare(second.length) != 0) {
       false
     } else {
       first.zip(second).forall{
@@ -37,10 +37,9 @@ object SignatureChecker {
     }
   }
 
-  def areSequentiallyCompatible(emitter: ModelField.Dict, receiver: ModelField.Dict): Boolean = {
-    receiver.data.forall {
-      case (name, field) =>
-        val emitterField = emitter.data.get(name)
+  def areSequentiallyCompatible(emitter: ModelField.ComplexField, receiver: ModelField.ComplexField): Boolean = {
+    receiver.data.forall { field =>
+        val emitterField = emitter.data.find(_.fieldName == field.fieldName)
         emitterField.exists(areSequentiallyCompatible(_, field))
     }
   }
@@ -49,12 +48,12 @@ object SignatureChecker {
     if (emitter == receiver) {
       true
     } else if (emitter.fieldName == receiver.fieldName) {
-      emitter.infoOrDict match {
-        case Empty => receiver.infoOrDict.isEmpty
-        case Dict(dict) =>
-          receiver.infoOrDict.dict.exists(areSequentiallyCompatible(dict, _))
+      emitter.infoOrSubfields match {
+        case Empty => receiver.infoOrSubfields.isEmpty
+        case Subfields(fields) =>
+          receiver.infoOrSubfields.subfields.exists(areSequentiallyCompatible(fields, _))
         case Info(tensor) =>
-          receiver.infoOrDict.info.exists(areSequentiallyCompatible(tensor, _))
+          receiver.infoOrSubfields.info.exists(areSequentiallyCompatible(tensor, _))
       }
     } else {
       false

--- a/common/src/main/scala/io/hydrosphere/serving/util/FileUtils.scala
+++ b/common/src/main/scala/io/hydrosphere/serving/util/FileUtils.scala
@@ -8,27 +8,25 @@ import java.io._
 object FileUtils {
 
   implicit class PumpedFile(file: File) {
-    def getSubDirectories: List[File] = {
-      if (file.listFiles() != null) {
-        file.listFiles().filter(_.isDirectory).toList
-      } else {
-        List.empty
-      }
+    def getSubDirectories: Seq[File] = {
+      Option(file.listFiles())
+        .getOrElse(Array.empty)
+        .filter(_.isDirectory)
     }
 
-    def listFilesRecursively: List[File] = {
+    def listFilesRecursively: Seq[File] = {
+      def _listChildFiles(f: File): Seq[File] = {
+        if (f.isFile)
+          Seq(f)
+        else {
+          f.listFiles().flatMap(_listChildFiles).toList
+        }
+      }
+
       if (file.isDirectory) {
         _listChildFiles(file)
       } else {
-        List.empty
-      }
-    }
-
-    private def _listChildFiles(f: File): List[File] = {
-      if (f.isFile)
-        List(f)
-      else {
-        f.listFiles().flatMap(_listChildFiles).toList
+        Seq.empty
       }
     }
   }

--- a/common/src/test/scala/ContractOpsSpecs.scala
+++ b/common/src/test/scala/ContractOpsSpecs.scala
@@ -185,7 +185,7 @@ class ContractOpsSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createDictModelField(
+            ModelContractBuilders.flatDictField(
               "in",
               Map(
                 "a" -> ModelContractBuilders.createTensorInfo("in1", DataType.DT_STRING, None),
@@ -194,7 +194,7 @@ class ContractOpsSpecs extends WordSpec {
             )
           ),
           List(
-            ModelContractBuilders.createDictModelField(
+            ModelContractBuilders.flatDictField(
               "out",
               Map(
                 "x" -> ModelContractBuilders.createTensorInfo("out1", DataType.DT_DOUBLE, Some(List(-1))),
@@ -238,6 +238,70 @@ class ContractOpsSpecs extends WordSpec {
         )
 
         assert(contract.flatten === expected)
+      }
+    }
+
+    "unflatten" when {
+      "non-nested contract" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+          ),
+          List(
+            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+          )
+        )
+
+        val flatSignature = SignatureDescription(
+          "sig1",
+          inputs = List(
+            FieldDescription("/in1", DataType.DT_STRING, None)
+          ),
+          outputs = List(
+            FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
+          )
+        )
+
+        assert(ContractOps.SignatureDescription.toSignature(flatSignature) === sig1)
+      }
+      "contract is nested" in {
+        val signature = ModelSignature(
+          "sig1",
+          List(
+            ModelContractBuilders.flatDictField(
+              "in",
+              Map(
+                "a" -> ModelContractBuilders.createTensorInfo("in1", DataType.DT_STRING, None),
+                "b" -> ModelContractBuilders.createTensorInfo("in2", DataType.DT_INT32, None)
+              )
+            )
+          ),
+          List(
+            ModelContractBuilders.flatDictField(
+              "out",
+              Map(
+                "x" -> ModelContractBuilders.createTensorInfo("out1", DataType.DT_DOUBLE, Some(List(-1))),
+                "y" -> ModelContractBuilders.createTensorInfo("out2", DataType.DT_INT32, None)
+              )
+            )
+          )
+        )
+
+        val signatureDescription = SignatureDescription(
+            "sig1",
+            inputs = List(
+              FieldDescription("/in/a/in1", DataType.DT_STRING, None),
+              FieldDescription("/in/b/in2", DataType.DT_INT32, None)
+            ),
+            outputs = List(
+              FieldDescription("/out/x/out1", DataType.DT_DOUBLE, Some(List(-1))),
+              FieldDescription("/out/y/out2", DataType.DT_INT32, None)
+            )
+          )
+
+
+        assert(ContractOps.SignatureDescription.toSignature(signatureDescription) === signature)
       }
     }
 

--- a/common/src/test/scala/ContractOpsSpecs.scala
+++ b/common/src/test/scala/ContractOpsSpecs.scala
@@ -185,20 +185,20 @@ class ContractOpsSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.flatDictField(
+            ModelContractBuilders.complexField(
               "in",
-              Map(
-                "a" -> ModelContractBuilders.createTensorInfo("in1", DataType.DT_STRING, None),
-                "b" -> ModelContractBuilders.createTensorInfo("in2", DataType.DT_INT32, None)
+              Seq(
+                ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None),
+                ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
               )
             )
           ),
           List(
-            ModelContractBuilders.flatDictField(
+            ModelContractBuilders.complexField(
               "out",
-              Map(
-                "x" -> ModelContractBuilders.createTensorInfo("out1", DataType.DT_DOUBLE, Some(List(-1))),
-                "y" -> ModelContractBuilders.createTensorInfo("out2", DataType.DT_INT32, None)
+              Seq(
+                ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+                ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, None)
               )
             )
           )
@@ -218,12 +218,12 @@ class ContractOpsSpecs extends WordSpec {
           SignatureDescription(
             "sig1",
             inputs = List(
-              FieldDescription("/in/a/in1", DataType.DT_STRING, None),
-              FieldDescription("/in/b/in2", DataType.DT_INT32, None)
+              FieldDescription("/in/in1", DataType.DT_STRING, None),
+              FieldDescription("/in/in2", DataType.DT_INT32, None)
             ),
             outputs = List(
-              FieldDescription("/out/x/out1", DataType.DT_DOUBLE, Some(List(-1))),
-              FieldDescription("/out/y/out2", DataType.DT_INT32, None)
+              FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
+              FieldDescription("/out/out2", DataType.DT_INT32, None)
             )
           ),
           SignatureDescription(
@@ -269,20 +269,21 @@ class ContractOpsSpecs extends WordSpec {
         val signature = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.flatDictField(
+            ModelContractBuilders.complexField(
               "in",
-              Map(
-                "a" -> ModelContractBuilders.createTensorInfo("in1", DataType.DT_STRING, None),
-                "b" -> ModelContractBuilders.createTensorInfo("in2", DataType.DT_INT32, None)
+              Seq(
+                ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None),
+                ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
               )
             )
           ),
           List(
-            ModelContractBuilders.flatDictField(
+            ModelContractBuilders.complexField(
               "out",
-              Map(
-                "x" -> ModelContractBuilders.createTensorInfo("out1", DataType.DT_DOUBLE, Some(List(-1))),
-                "y" -> ModelContractBuilders.createTensorInfo("out2", DataType.DT_INT32, None)
+              Seq(
+                ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+                ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, None)
+
               )
             )
           )
@@ -291,17 +292,18 @@ class ContractOpsSpecs extends WordSpec {
         val signatureDescription = SignatureDescription(
             "sig1",
             inputs = List(
-              FieldDescription("/in/a/in1", DataType.DT_STRING, None),
-              FieldDescription("/in/b/in2", DataType.DT_INT32, None)
+              FieldDescription("/in/in1", DataType.DT_STRING, None),
+              FieldDescription("/in/in2", DataType.DT_INT32, None)
             ),
             outputs = List(
-              FieldDescription("/out/x/out1", DataType.DT_DOUBLE, Some(List(-1))),
-              FieldDescription("/out/y/out2", DataType.DT_INT32, None)
+              FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
+              FieldDescription("/out/out2", DataType.DT_INT32, None)
             )
           )
 
+        val restored = ContractOps.SignatureDescription.toSignature(signatureDescription)
 
-        assert(ContractOps.SignatureDescription.toSignature(signatureDescription) === signature)
+        assert(restored === signature)
       }
     }
 

--- a/common/src/test/scala/ContractOpsSpecs.scala
+++ b/common/src/test/scala/ContractOpsSpecs.scala
@@ -20,31 +20,31 @@ class ContractOpsSpecs extends WordSpec {
           val sig1 = ModelSignature(
             "sig1",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
             )
           )
           val sig2 = ModelSignature(
             "sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+              ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
             )
           )
 
           val expectedSig = ModelSignature(
             "sig1&sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None),
-              ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None),
+              ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
-              ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+              ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
             )
           )
 
@@ -55,30 +55,30 @@ class ContractOpsSpecs extends WordSpec {
           val sig1 = ModelSignature(
             "sig1",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_INT32, Some(List(-1)))
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, Some(List(-1)))
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
             )
           )
           val sig2 = ModelSignature(
             "sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, Some(List(3)))
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
             )
           )
 
           val expectedSig = ModelSignature(
             "sig1&sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, Some(List(3)))
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
-              ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+              ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
             )
           )
 
@@ -91,19 +91,19 @@ class ContractOpsSpecs extends WordSpec {
           val sig1 = ModelSignature(
             "sig1",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
             )
           )
           val sig2 = ModelSignature(
             "sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_INT32, None)
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
             )
           )
 
@@ -114,19 +114,19 @@ class ContractOpsSpecs extends WordSpec {
           val sig1 = ModelSignature(
             "sig1",
             List(
-              ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
             )
           )
           val sig2 = ModelSignature(
             "sig2",
             List(
-              ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+              ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
             ),
             List(
-              ModelContractBuilders.createTensorModelField("out1", DataType.DT_INT32, Some(List(3)))
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, Some(List(3)))
             )
           )
 
@@ -140,19 +140,19 @@ class ContractOpsSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+            ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
           )
         )
         val sig2 = ModelSignature(
           "sig2",
           List(
-            ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+            ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+            ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
           )
         )
         val contract = ModelContract("test",List(sig1, sig2))
@@ -188,8 +188,8 @@ class ContractOpsSpecs extends WordSpec {
             ModelContractBuilders.complexField(
               "in",
               Seq(
-                ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None),
-                ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+                ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None),
+                ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
               )
             )
           ),
@@ -197,8 +197,8 @@ class ContractOpsSpecs extends WordSpec {
             ModelContractBuilders.complexField(
               "out",
               Seq(
-                ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
-                ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, None)
+                ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+                ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, None)
               )
             )
           )
@@ -206,10 +206,10 @@ class ContractOpsSpecs extends WordSpec {
         val sig2 = ModelSignature(
           "sig2",
           List(
-            ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+            ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
+            ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, Some(List(3)))
           )
         )
         val contract = ModelContract("test",List(sig1, sig2))
@@ -246,10 +246,10 @@ class ContractOpsSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+            ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
           )
         )
 
@@ -272,8 +272,8 @@ class ContractOpsSpecs extends WordSpec {
             ModelContractBuilders.complexField(
               "in",
               Seq(
-                ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None),
-                ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, None)
+                ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None),
+                ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, None)
               )
             )
           ),
@@ -281,8 +281,8 @@ class ContractOpsSpecs extends WordSpec {
             ModelContractBuilders.complexField(
               "out",
               Seq(
-                ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
-                ModelContractBuilders.createTensorModelField("out2", DataType.DT_INT32, None)
+                ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1))),
+                ModelContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, None)
 
               )
             )

--- a/common/src/test/scala/DataGeneratorSpecs.scala
+++ b/common/src/test/scala/DataGeneratorSpecs.scala
@@ -1,4 +1,5 @@
 import com.google.protobuf.ByteString
+import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
 import io.hydrosphere.serving.model_api.{DataGenerator, ModelContractBuilders}
 import io.hydrosphere.serving.tensorflow.tensor.TensorProto
@@ -52,10 +53,10 @@ class DataGeneratorSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.flatDictField("in1",
-              Map(
-                "a" -> ModelContractBuilders.createTensorInfo("a", DataType.DT_STRING, None),
-                "b" -> ModelContractBuilders.createTensorInfo("b", DataType.DT_STRING, None)
+            ModelContractBuilders.complexField("in1",
+              Seq(
+                ModelContractBuilders.createTensorModelField("a", DataType.DT_STRING, None),
+                ModelContractBuilders.createTensorModelField("b", DataType.DT_STRING, None)
               )
             )
           ),

--- a/common/src/test/scala/DataGeneratorSpecs.scala
+++ b/common/src/test/scala/DataGeneratorSpecs.scala
@@ -13,10 +13,10 @@ class DataGeneratorSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, None)
+            ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
           )
         )
 
@@ -32,11 +32,11 @@ class DataGeneratorSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createTensorModelField("in1", DataType.DT_STRING, Some(List(-1))),
-            ModelContractBuilders.createTensorModelField("in2", DataType.DT_INT32, Some(List(3)))
+            ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, Some(List(-1))),
+            ModelContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, Some(List(3)))
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
           )
         )
 
@@ -55,13 +55,13 @@ class DataGeneratorSpecs extends WordSpec {
           List(
             ModelContractBuilders.complexField("in1",
               Seq(
-                ModelContractBuilders.createTensorModelField("a", DataType.DT_STRING, None),
-                ModelContractBuilders.createTensorModelField("b", DataType.DT_STRING, None)
+                ModelContractBuilders.simpleTensorModelField("a", DataType.DT_STRING, None),
+                ModelContractBuilders.simpleTensorModelField("b", DataType.DT_STRING, None)
               )
             )
           ),
           List(
-            ModelContractBuilders.createTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
           )
         )
 

--- a/common/src/test/scala/DataGeneratorSpecs.scala
+++ b/common/src/test/scala/DataGeneratorSpecs.scala
@@ -52,7 +52,7 @@ class DataGeneratorSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelContractBuilders.createDictModelField("in1",
+            ModelContractBuilders.flatDictField("in1",
               Map(
                 "a" -> ModelContractBuilders.createTensorInfo("a", DataType.DT_STRING, None),
                 "b" -> ModelContractBuilders.createTensorInfo("b", DataType.DT_STRING, None)

--- a/common/src/test/scala/SignatureCheckerSpecs.scala
+++ b/common/src/test/scala/SignatureCheckerSpecs.scala
@@ -14,19 +14,19 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelField("in1", ModelField.InfoOrDict.Info(TensorInfo("in1", DataType.DT_STRING, None)))
+            ModelField("in1", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_STRING, None)))
           ),
           List(
-            ModelField("out1", ModelField.InfoOrDict.Info(TensorInfo("out1", DataType.DT_STRING, None)))
+            ModelField("out1", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_STRING, None)))
           )
         )
         val sig2 = ModelSignature(
           "sig2",
           List(
-            ModelField("out1", ModelField.InfoOrDict.Info(TensorInfo("out1", DataType.DT_STRING, None)))
+            ModelField("out1", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_STRING, None)))
           ),
           List(
-            ModelField("out2", ModelField.InfoOrDict.Info(TensorInfo("out2", DataType.DT_STRING, None)))
+            ModelField("out2", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_STRING, None)))
           )
         )
         assert(SignatureChecker.areSequentiallyCompatible(sig1, sig2))
@@ -36,18 +36,16 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
             ModelField("in1",
-              ModelField.InfoOrDict.Info(
+              ModelField.InfoOrSubfields.Info(
                 TensorInfo(
-                  "in1",
                   DataType.DT_DOUBLE,
                   Some(TensorShapeProto(TensorShapeProto.Dim(5) :: Nil))
                 )
               )
             ) :: Nil,
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_DOUBLE,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: Nil))
               )
@@ -57,18 +55,16 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig2 = ModelSignature(
           "sig2",
             ModelField("out1",
-              ModelField.InfoOrDict.Info(
+              ModelField.InfoOrSubfields.Info(
                 TensorInfo(
-                  "out1",
                   DataType.DT_DOUBLE,
                   Some(TensorShapeProto(TensorShapeProto.Dim(5) :: Nil))
                 )
               )
             ) :: Nil,
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_DOUBLE,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: Nil))
               )
@@ -83,9 +79,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -93,9 +88,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -106,9 +100,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig2",
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(-1) :: Nil))
               )
@@ -116,9 +109,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(-1) :: Nil))
               )
@@ -133,9 +125,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -143,9 +134,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -156,9 +146,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig2",
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -166,9 +155,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -183,9 +171,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -193,9 +180,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(2) :: Nil))
               )
@@ -206,9 +192,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig2",
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(-1) :: Nil))
               )
@@ -216,9 +201,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_INT32,
                 Some(TensorShapeProto(TensorShapeProto.Dim(5) :: TensorShapeProto.Dim(-1) :: Nil))
               )
@@ -235,13 +219,13 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           List(
-            ModelField("in1", ModelField.InfoOrDict.Info(TensorInfo("in1", DataType.DT_STRING, None)))
+            ModelField("in1", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_STRING, None)))
           )
         )
         val sig2 = ModelSignature(
           "sig2",
           List(
-            ModelField("in2", ModelField.InfoOrDict.Info(TensorInfo("in2", DataType.DT_INT32, None)))
+            ModelField("in2", ModelField.InfoOrSubfields.Info(TensorInfo(DataType.DT_INT32, None)))
           )
         )
         assert(! SignatureChecker.areSequentiallyCompatible(sig1, sig2))
@@ -252,9 +236,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -262,9 +245,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -275,9 +257,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig2",
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(4) :: Nil))
               )
@@ -285,9 +266,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(4) :: Nil))
               )
@@ -302,9 +282,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(4) :: Nil))
               )
@@ -312,9 +291,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(4) :: Nil))
               )
@@ -325,9 +303,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig2",
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_DOUBLE,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -335,9 +312,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out2",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out2",
                 DataType.DT_DOUBLE,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -352,9 +328,8 @@ class SignatureCheckerSpecs extends WordSpec {
           "sig1",
 
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -362,9 +337,8 @@ class SignatureCheckerSpecs extends WordSpec {
           ) :: Nil,
 
           ModelField("out1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "out1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -379,9 +353,8 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig1 = ModelSignature(
           "sig1",
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )
@@ -391,9 +364,8 @@ class SignatureCheckerSpecs extends WordSpec {
         val sig2 = ModelSignature(
           "sig2",
           ModelField("in1",
-            ModelField.InfoOrDict.Info(
+            ModelField.InfoOrSubfields.Info(
               TensorInfo(
-                "in1",
                 DataType.DT_STRING,
                 Some(TensorShapeProto(TensorShapeProto.Dim(3) :: Nil))
               )

--- a/manager/src/it/scala/io/hydrosphere/serving/manager/service/ModelManagementServiceITSpec.scala
+++ b/manager/src/it/scala/io/hydrosphere/serving/manager/service/ModelManagementServiceITSpec.scala
@@ -2,9 +2,12 @@ package io.hydrosphere.serving.manager.service
 
 import io.hydrosphere.serving.contract.model_contract.ModelContract
 import io.hydrosphere.serving.manager.test.CommonIntegrationSpec
+import io.hydrosphere.serving.model_api.ContractOps.{ContractDescription, FieldDescription, SignatureDescription}
 import io.hydrosphere.serving.model_api._
-import org.scalactic.source.Position
+import io.hydrosphere.serving.tensorflow.types.DataType
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
+import ContractOps.Implicits._
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -15,14 +18,14 @@ import scala.concurrent.duration._
 class ModelManagementServiceITSpec extends CommonIntegrationSpec with BeforeAndAfterEach {
 
   describe("Model") {
-    it("Fetch all models") {
+    it("should fetch all models") {
       val f = managerServices.modelManagementService.allModels().map(seq => {
-        assert(seq.size == 1)
+        assert(seq.lengthCompare(1) === 0)
       })
       Await.result(f, 10.seconds)
     }
 
-    it("Create model") {
+    it("should create model") {
       val request = CreateOrUpdateModelRequest(
         id = None,
         name = "Test222",
@@ -32,14 +35,84 @@ class ModelManagementServiceITSpec extends CommonIntegrationSpec with BeforeAndA
         modelType = ModelType.Unknown()
       )
       val f = managerServices.modelManagementService.createModel(request).map{ model =>
-        assert(model.name == request.name)
-        assert(model.source == request.source)
-        assert(model.description == request.description)
-        assert(model.modelContract == request.modelContract)
-        assert(model.updated != null)
-        assert(model.created != null)
+        assert(model.name === request.name)
+        assert(model.source === request.source)
+        assert(model.description === request.description)
+        assert(model.modelContract === request.modelContract)
+        assert(model.updated !== null)
+        assert(model.created !== null)
       }
       Await.result(f, 10.seconds)
+    }
+
+    it("should update a flat model contract") {
+      val flatContract = ContractDescription(
+        List(
+          SignatureDescription(
+            "sig1",
+            inputs = List(
+              FieldDescription("/in1", DataType.DT_STRING, None)
+            ),
+            outputs = List(
+              FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
+            )
+          )
+        )
+      )
+
+      val f = managerServices.modelManagementService.submitFlatContract(1000, flatContract)
+      val maybeModel = Await.result(f, 10.seconds)
+      assert(maybeModel.isDefined)
+
+      val newF = managerRepositories.modelRepository.get(1000)
+      val maybeNewModel = Await.result(newF, 10.seconds)
+      assert(maybeNewModel.isDefined)
+      val newModel = maybeNewModel.get
+      assert(newModel.modelContract.flatten === flatContract)
+    }
+
+    it("should update a text model contract") {
+      val contract = ModelSignature(
+        "sig1",
+        List(
+          ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
+        ),
+        List(
+          ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+        )
+      )
+
+      val f = managerServices.modelManagementService.submitContract(1000, contract.toString())
+      val maybeModel = Await.result(f, 10.seconds)
+      assert(maybeModel.isDefined)
+
+      val newF = managerRepositories.modelRepository.get(1000)
+      val maybeNewModel = Await.result(newF, 10.seconds)
+      assert(maybeNewModel.isDefined)
+      val newModel = maybeNewModel.get
+      assert(newModel.modelContract === contract)
+    }
+
+    it("should update a binary model contract") {
+      val contract = ModelSignature(
+        "sig1",
+        List(
+          ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
+        ),
+        List(
+          ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+        )
+      )
+
+      val f = managerServices.modelManagementService.submitBinaryContract(1000, contract.toByteArray)
+      val maybeModel = Await.result(f, 10.seconds)
+      assert(maybeModel.isDefined)
+
+      val newF = managerRepositories.modelRepository.get(1000)
+      val maybeNewModel = Await.result(newF, 10.seconds)
+      assert(maybeNewModel.isDefined)
+      val newModel = maybeNewModel.get
+      assert(newModel.modelContract === contract)
     }
   }
 

--- a/manager/src/it/scala/io/hydrosphere/serving/manager/service/ModelManagementServiceITSpec.scala
+++ b/manager/src/it/scala/io/hydrosphere/serving/manager/service/ModelManagementServiceITSpec.scala
@@ -72,13 +72,18 @@ class ModelManagementServiceITSpec extends CommonIntegrationSpec with BeforeAndA
     }
 
     it("should update a text model contract") {
-      val contract = ModelSignature(
-        "sig1",
-        List(
-          ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
-        ),
-        List(
-          ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+      val contract = ModelContract(
+        modelName = "",
+        signatures = List(
+          ModelSignature(
+            "sig1",
+            List(
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
+            ),
+            List(
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            )
+          )
         )
       )
 
@@ -94,13 +99,18 @@ class ModelManagementServiceITSpec extends CommonIntegrationSpec with BeforeAndA
     }
 
     it("should update a binary model contract") {
-      val contract = ModelSignature(
-        "sig1",
-        List(
-          ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
-        ),
-        List(
-          ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+      val contract = ModelContract(
+        modelName = "",
+        signatures = List(
+          ModelSignature(
+            "sig1",
+            List(
+              ModelContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, None)
+            ),
+            List(
+              ModelContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, Some(List(-1)))
+            )
+          )
         )
       )
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/actor/modelsource/LocalSourceWatcher.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/actor/modelsource/LocalSourceWatcher.scala
@@ -75,6 +75,7 @@ class LocalSourceWatcher(val source: LocalModelSource) extends SourceWatcher {
               .map(_.toPath)
               .map(source.sourceFile.toPath.relativize)
               .map(handleCreation)
+              .toList
           } else {
             List(handleCreation(relativePath))
           }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/controller/ui/UISpecificController.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/controller/ui/UISpecificController.scala
@@ -8,7 +8,7 @@ import akka.util.Timeout
 import io.hydrosphere.serving.controller.{ServingDataDirectives, TracingHeaders}
 import io.hydrosphere.serving.manager.controller.BuildModelRequest
 import io.hydrosphere.serving.manager.service.{ModelInfo, UIManagementService}
-import io.hydrosphere.serving.model_api.ContractOps.SignatureDescription
+import io.hydrosphere.serving.model_api.ContractOps.{ContractDescription, SignatureDescription}
 import io.swagger.annotations._
 
 import scala.concurrent.duration._
@@ -53,7 +53,7 @@ class UISpecificController(
     new ApiImplicitParam(name = "runtimeId", required = true, dataType = "long", paramType = "path", value = "modelId")
   ))
   @ApiResponses(Array(
-    new ApiResponse(code = 200, message = "SignatureDescription", responseContainer = "List", response=classOf[SignatureDescription]),
+    new ApiResponse(code = 200, message = "ContractDescription", response=classOf[ContractDescription]),
     new ApiResponse(code = 500, message = "Internal server error")
   ))
   def getContract = path("ui" / "v1" / "model" / "contract" / LongNumber) { runtimeId =>

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/UIManagementService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/UIManagementService.scala
@@ -12,7 +12,7 @@ import io.hydrosphere.serving.manager.actor.ContainerWatcher.{Started, WatchForS
 import io.hydrosphere.serving.manager.model._
 import io.hydrosphere.serving.manager.repository.{ModelBuildRepository, ModelRepository, ModelRuntimeRepository, ModelServiceRepository}
 import io.hydrosphere.serving.model._
-import io.hydrosphere.serving.model_api.ContractOps.SignatureDescription
+import io.hydrosphere.serving.model_api.ContractOps.{ContractDescription, SignatureDescription}
 import org.apache.logging.log4j.scala.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -85,7 +85,7 @@ case class ApplicationDetails(
 )
 
 trait UIManagementService {
-  def flattenContract(runtimeId: Long): Future[Option[List[SignatureDescription]]]
+  def flattenContract(runtimeId: Long): Future[Option[ContractDescription]]
 
   def createApplication(req: UIApplicationCreateOrUpdateRequest): Future[ApplicationDetails]
 
@@ -494,7 +494,7 @@ class UIManagementServiceImpl(
       })
     }
 
-  override def flattenContract(runtimeId: Long): Future[Option[List[SignatureDescription]]] = {
+  override def flattenContract(runtimeId: Long): Future[Option[ContractDescription]] = {
     import io.hydrosphere.serving.model_api.ContractOps.Implicits._
 
     modelRuntimeRepository.get(runtimeId).map {

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/TensorflowModelFetcher.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/TensorflowModelFetcher.scala
@@ -60,7 +60,6 @@ object TensorflowModelFetcher extends ModelFetcher with Logging {
     } else None
     val convertedDtype = DataType.fromValue(tensorInfo.getDtypeValue)
     TensorInfo(
-      name = tensorInfo.getName,
       dtype = convertedDtype,
       tensorShape = shape
     )
@@ -70,16 +69,15 @@ object TensorflowModelFetcher extends ModelFetcher with Logging {
     tensorMap.map {
       case (inputName, inputDef) =>
         val convertedInputDef = convertTensor(inputDef)
-        val tensorInfo = ModelField.InfoOrDict.Info(
+        val tensorInfo = ModelField.InfoOrSubfields.Info(
           TensorInfo(
-            inputName,
             convertedInputDef.dtype,
             convertedInputDef.tensorShape
           )
         )
         ModelField(
           fieldName = inputName,
-          infoOrDict = tensorInfo
+          infoOrSubfields = tensorInfo
         )
     }.toList
   }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/Feature.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/Feature.scala
@@ -4,9 +4,10 @@ import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.tensorflow.tensor_info.TensorInfo
 import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
 import io.hydrosphere.serving.tensorflow.types.DataType
-import io.hydrosphere.serving.tensorflow.types.DataType.{DT_DOUBLE, DT_STRING}
+import io.hydrosphere.serving.tensorflow.types.DataType.{DT_DOUBLE, DT_STRING, DT_VARIANT}
 import io.hydrosphere.serving.manager.service.modelfetcher.spark.SparkModelMetadata
 import io.hydrosphere.serving.manager.service.modelfetcher.spark.mappers.SparkMlTypeMapper._
+import io.hydrosphere.serving.model_api.ModelContractBuilders
 
 class HashingTFMapper(m: SparkModelMetadata)  extends InputOutputMapper(m) {
   override def inputType(sparkModelMetadata: SparkModelMetadata): TypeDescription = varVec(DT_STRING)
@@ -129,16 +130,7 @@ class VectorAssemblerMapper(m: SparkModelMetadata)  extends SparkMlTypeMapper(m)
     m.getParam[Seq[String]]("inputCols")
       .map{
         _.map{ col =>
-          ModelField(
-            col,
-            ModelField.InfoOrDict.Info(
-              TensorInfo(
-                col,
-                DataType.DT_VARIANT,
-                Some(TensorShapeProto(unknownRank = true))
-              )
-            )
-          )
+          ModelContractBuilders.simpleTensorModelField(col, DT_VARIANT, Some(Seq.empty), unknownRank = true)
         }
       }
       .getOrElse(

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/PredictorMapper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/PredictorMapper.scala
@@ -1,10 +1,10 @@
 package io.hydrosphere.serving.manager.service.modelfetcher.spark.mappers
 
 import io.hydrosphere.serving.contract.model_field.ModelField
-import io.hydrosphere.serving.tensorflow.tensor_info.TensorInfo
 import io.hydrosphere.serving.tensorflow.types.DataType.{DT_DOUBLE, DT_STRING}
 import io.hydrosphere.serving.manager.service.modelfetcher.spark.SparkModelMetadata
 import io.hydrosphere.serving.manager.service.modelfetcher.spark.mappers.SparkMlTypeMapper.{TypeDescription, constructField, scalar}
+import io.hydrosphere.serving.model_api.ModelContractBuilders
 
 abstract class PredictorMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(m) {
   def featuresType(sparkModelMetadata: SparkModelMetadata): TypeDescription = SparkMlTypeMapper.featuresVec(sparkModelMetadata)
@@ -14,16 +14,7 @@ abstract class PredictorMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(
     val name = m.getParam[String]("labelCol").get
     Some(
       List(
-        ModelField(
-          name,
-          ModelField.InfoOrDict.Info(
-            TensorInfo(
-              name,
-              DT_STRING,
-              None
-            )
-          )
-        )
+        ModelContractBuilders.rawTensorModelField(name, DT_STRING, None)
       )
     )
   }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/SparkMlTypeMapper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/SparkMlTypeMapper.scala
@@ -5,6 +5,7 @@ import io.hydrosphere.serving.tensorflow.tensor_info.TensorInfo
 import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
 import io.hydrosphere.serving.tensorflow.types.DataType
 import io.hydrosphere.serving.manager.service.modelfetcher.spark._
+import io.hydrosphere.serving.model_api.ModelContractBuilders
 
 abstract class SparkMlTypeMapper(val m: SparkModelMetadata) {
 
@@ -17,8 +18,7 @@ object SparkMlTypeMapper {
   type TypeDescription = (DataType, Option[TensorShapeProto])
 
   def constructField(name: String, typeDescription: TypeDescription): ModelField = {
-    val tensorInfo = TensorInfo(name, typeDescription._1, typeDescription._2)
-    ModelField(name, ModelField.InfoOrDict.Info(tensorInfo))
+    ModelContractBuilders.rawTensorModelField(name, typeDescription._1, typeDescription._2)
   }
 
   def scalar(dataType: DataType): TypeDescription = {

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/UntypedMapper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelfetcher/spark/mappers/UntypedMapper.scala
@@ -5,6 +5,7 @@ import io.hydrosphere.serving.tensorflow.tensor_info.TensorInfo
 import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
 import io.hydrosphere.serving.tensorflow.types.DataType
 import io.hydrosphere.serving.manager.service.modelfetcher.spark.SparkModelMetadata
+import io.hydrosphere.serving.model_api.ModelContractBuilders
 
 class UntypedMapper(m: SparkModelMetadata)  extends SparkMlTypeMapper(m) {
   private[this] val inputCols = Array("inputCol", "featuresCol")
@@ -14,50 +15,34 @@ class UntypedMapper(m: SparkModelMetadata)  extends SparkMlTypeMapper(m) {
   override def inputSchema: List[ModelField] = {
     inputCols
       .map(m.getParam[String])
-      .map {
+      .flatMap {
         _.map {
           inputName =>
-            ModelField(
+            ModelContractBuilders.simpleTensorModelField(
               inputName,
-              ModelField.InfoOrDict.Info(
-                TensorInfo(
-                  inputName,
-                  DataType.DT_STRING,
-                  Some(
-                    TensorShapeProto(unknownRank = true)
-                  )
-                )
-              )
+              DataType.DT_STRING,
+              Some(Seq.empty),
+              unknownRank = true
             )
         }
       }
-      .filter(_.isDefined)
-      .map(_.get)
       .toList
   }
 
   override def outputSchema: List[ModelField] = {
     outputCols
       .map(m.getParam[String])
-      .map {
+      .flatMap {
         _.map {
           inputName =>
-            ModelField(
+            ModelContractBuilders.simpleTensorModelField(
               inputName,
-              ModelField.InfoOrDict.Info(
-                TensorInfo(
-                  inputName,
-                  DataType.DT_STRING,
-                  Some(
-                    TensorShapeProto(unknownRank = true)
-                  )
-                )
-              )
+              DataType.DT_STRING,
+              Some(Seq.empty),
+              unknownRank = true
             )
         }
       }
-      .filter(_.isDefined)
-      .map(_.get)
       .toList
   }
 }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelsource/local/LocalModelSource.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/modelsource/local/LocalModelSource.scala
@@ -18,19 +18,28 @@ class LocalModelSource(val sourceDef: LocalSourceDef) extends ModelSource {
   }
 
   override def getSubDirs(path: String): List[String] = {
-    val fullPath = Paths.get(sourceDef.path.toString, path)
-    fullPath.toFile.getSubDirectories
+    Paths.get(sourceDef.path.toString, path)
+      .toFile
+      .getSubDirectories
       .map(_.getName)
+      .toList
   }
 
   override def getSubDirs: List[String] = {
-    sourceFile.getSubDirectories.map(_.getName)
+    sourceFile
+      .getSubDirectories
+      .map(_.getName)
+      .toList
   }
 
   override def getAllFiles(modelName: String): List[String] = {
     val fullPath = Paths.get(sourceDef.path.toString, modelName)
     val fullUri = fullPath.toUri
-    fullPath.toFile.listFilesRecursively.map(p => fullUri.relativize(p.toURI).toString)
+    fullPath
+      .toFile
+      .listFilesRecursively
+      .map(p => fullUri.relativize(p.toURI).toString)
+      .toList
   }
 
   override def getAbsolutePath(modelPath: String): Path = {


### PR DESCRIPTION
Provide API to edit the contract:
For specified model user should be able to submit:
- a raw proto message ModelContract (binary/text)
- a flattened contract description.