### PR TITLE
Shape inference improvements and fixes

### DIFF
--- a/manager/src/main/scala/io/hydrosphere/serving/manager/controller/model/ModelController.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/controller/model/ModelController.scala
@@ -10,9 +10,9 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import io.hydrosphere.serving.contract.model_contract.ModelContract
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
 import io.hydrosphere.serving.manager.controller.{GenericController, ServingDataDirectives}
 import io.hydrosphere.serving.manager.model._
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import io.hydrosphere.serving.manager.model.db.{Model, ModelBuild, ModelVersion}
 import io.hydrosphere.serving.manager.service.aggregated_info.{AggregatedInfoUtilityService, AggregatedModelInfo}
 import io.hydrosphere.serving.manager.service.model.{CreateModelRequest, ModelManagementService, UpdateModelRequest}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGenerator.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGenerator.scala
@@ -1,0 +1,82 @@
+package io.hydrosphere.serving.manager.model.api
+
+import io.hydrosphere.serving.contract.model_contract.ModelContract
+import io.hydrosphere.serving.contract.model_field.ModelField
+import io.hydrosphere.serving.contract.model_field.ModelField.TypeOrSubfields.{Dtype, Empty, Subfields}
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.{AnyDims, Dims}
+import io.hydrosphere.serving.tensorflow.tensor.{MapTensor, TypedTensor, TypedTensorFactory}
+import io.hydrosphere.serving.tensorflow.types.DataType
+import io.hydrosphere.serving.tensorflow.types.DataType.{DT_BOOL, DT_COMPLEX128, DT_COMPLEX64, DT_DOUBLE, DT_FLOAT, DT_INT16, DT_INT32, DT_INT64, DT_INT8, DT_INVALID, DT_QINT16, DT_QINT32, DT_QINT8, DT_QUINT16, DT_QUINT8, DT_STRING, DT_UINT16, DT_UINT32, DT_UINT64, DT_UINT8}
+
+case class TensorExampleGenerator(modelApi: ModelSignature) {
+  def inputs: Map[String, TypedTensor[_]] = {
+    modelApi.inputs.flatMap(TensorExampleGenerator.generateField).toMap
+  }
+
+  def outputs: Map[String, TypedTensor[_]] = {
+    modelApi.outputs.flatMap(TensorExampleGenerator.generateField).toMap
+  }
+}
+
+object TensorExampleGenerator {
+  def forContract(modelContract: ModelContract, signature: String): Option[TensorExampleGenerator] = {
+    modelContract.signatures.find(_.signatureName == signature).map(TensorExampleGenerator.apply)
+  }
+
+  def generateScalarData[T <: DataType](dataType: T): Any = {
+    dataType match {
+      case DT_FLOAT | DT_COMPLEX64 => 1.0F
+      case DT_DOUBLE | DT_COMPLEX128 => 1.0D
+      case DT_INT8 | DT_INT16 | DT_INT32 | DT_UINT8 | DT_UINT16 | DT_UINT32 | DT_QINT8 | DT_QINT16 |
+           DT_QINT32 | DT_QUINT8 | DT_QUINT16 =>
+        1
+      case DT_INT64 | DT_UINT64 => 1L
+      case DT_STRING => "foo"
+      case DT_BOOL => true
+
+      case DT_INVALID =>
+        throw new IllegalArgumentException(
+          s"Can't convert data to DT_INVALID"
+        )
+      case x => throw new IllegalArgumentException(s"Cannot process Tensor with $x dtype") // refs
+    }
+  }
+
+  def createFlatTensor[T](shape: TensorShape, generator: => T): Seq[T] = {
+    shape match {
+      case AnyDims() => List(generator)
+      case Dims(dims, _) if dims.isEmpty => List(generator)
+      case Dims(dims, _) =>
+        val flatLen = dims.map(_.max(1)).product
+        (1L to flatLen).map(_ => generator) // mat
+    }
+  }
+
+  def generateTensor(shape: TensorShape, dtype: DataType): Option[TypedTensor[_]] = {
+    val factory = TypedTensorFactory(dtype)
+    val data = createFlatTensor(shape, generateScalarData(dtype))
+    factory.createFromAny(data, shape)
+  }
+
+  def generateField(field: ModelField): Map[String, TypedTensor[_]] = {
+    val shape = TensorShape(field.shape)
+    val fieldValue = field.typeOrSubfields match {
+      case Empty => None
+      case Dtype(value) => generateTensor(shape, value)
+      case Subfields(value) => generateNestedTensor(shape, value)
+    }
+    fieldValue.map(x => field.name -> x).toMap
+  }
+
+  private def generateNestedTensor(shape: TensorShape, value: ModelField.Subfield): Option[MapTensor] = {
+    val map = generateMap(value)
+    val tensorData = createFlatTensor(shape, map)
+    Some(MapTensor(shape, tensorData))
+  }
+
+  private def generateMap(value: ModelField.Subfield): Map[String, TypedTensor[_]] = {
+    value.data.flatMap(generateField).toMap
+  }
+}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/ContractDescription.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/ContractDescription.scala
@@ -1,0 +1,17 @@
+package io.hydrosphere.serving.manager.model.api.description
+
+import io.hydrosphere.serving.contract.model_contract.ModelContract
+
+case class ContractDescription(
+  signatures: Seq[SignatureDescription]
+) {
+  def toContract: ModelContract = ContractDescription.toContract(this)
+}
+
+object ContractDescription {
+  def toContract(contractDescription: ContractDescription): ModelContract = {
+    ModelContract(
+      signatures = contractDescription.signatures.map(SignatureDescription.toSignature)
+    )
+  }
+}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/FieldDescription.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/FieldDescription.scala
@@ -1,0 +1,9 @@
+package io.hydrosphere.serving.manager.model.api.description
+
+import io.hydrosphere.serving.tensorflow.types.DataType
+
+case class FieldDescription(
+  fieldName: String,
+  dataType: DataType,
+  shape: Option[Seq[Long]]
+)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/SignatureDescription.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/description/SignatureDescription.scala
@@ -1,0 +1,124 @@
+package io.hydrosphere.serving.manager.model.api.description
+
+import io.hydrosphere.serving.contract.model_field.ModelField
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.{AnyDims, Dims}
+import io.hydrosphere.serving.tensorflow.types.DataType
+
+import scala.collection.mutable
+
+case class SignatureDescription(
+  signatureName: String,
+  inputs: Seq[FieldDescription],
+  outputs: Seq[FieldDescription]
+) {
+  def toSignature: ModelSignature = SignatureDescription.toSignature(this)
+}
+
+object SignatureDescription {
+
+  class Converter() {
+
+    sealed trait ANode {
+      def name: String
+
+      def shape: TensorShape
+
+      def toTypeOrSubfields: ModelField.TypeOrSubfields
+    }
+
+    case class FTensor(name: String, shape: TensorShape, dtype: DataType) extends ANode {
+      override def toTypeOrSubfields = {
+        ModelField.TypeOrSubfields.Dtype(dtype)
+      }
+    }
+
+    case class FMap(name: String = "", shape: TensorShape = AnyDims(), data: mutable.ListBuffer[ANode] = mutable.ListBuffer.empty)
+      extends ANode {
+      def getOrUpdate(segment: String, map: FMap): ANode = {
+        data.find(_.name == segment) match {
+          case Some(x) =>
+            x
+          case None =>
+            data += map
+            map
+        }
+      }
+
+      def +=(node: ANode): data.type = data += node
+
+      override def toTypeOrSubfields = {
+        ModelField.TypeOrSubfields.Subfields(
+          ModelField.Subfield(
+            data.map { node =>
+              ModelField(node.name, node.shape.toProto, node.toTypeOrSubfields)
+            }
+          )
+        )
+      }
+    }
+
+    private val tree = FMap()
+
+    /**
+      * Mutates tree to represent contract field in tree-like structure.
+      * Inner state is contained in `tree` variable.
+      *
+      * @param field flattened field description
+      */
+    def acceptField(field: FieldDescription): Unit = {
+      val shape = field.shape match {
+        case Some(x) => Dims(x)
+        case None => AnyDims()
+      }
+      field.fieldName.split("/").drop(1).toList match {
+        case tensorName :: Nil =>
+          tree += FTensor(
+            tensorName,
+            shape,
+            field.dataType
+          )
+        case root :: segments =>
+          var last = tree.getOrUpdate(root, FMap(root)).asInstanceOf[FMap]
+
+          segments.init.foreach { segment =>
+            val segField = last.getOrUpdate(segment, FMap(segment)).asInstanceOf[FMap]
+            last += segField
+            last = segField
+          }
+
+          val lastName = segments.last
+          last += FTensor(
+            lastName,
+            shape,
+            field.dataType
+          )
+        case Nil =>
+          throw new IllegalArgumentException(
+            s"Field name '${field.fieldName}' in flattened contract is incorrect."
+          )
+      }
+    }
+
+    def result: Seq[ModelField] = {
+      tree.data.map { node =>
+        ModelField(node.name, node.shape.toProto, node.toTypeOrSubfields)
+      }
+    }
+  }
+
+  def toSignature(signatureDescription: SignatureDescription): ModelSignature = {
+    ModelSignature(
+      signatureName = signatureDescription.signatureName,
+      inputs = SignatureDescription.toFields(signatureDescription.inputs),
+      outputs = SignatureDescription.toFields(signatureDescription.outputs)
+    )
+  }
+
+  def toFields(fields: Seq[FieldDescription]): Seq[ModelField] = {
+    val converter = new Converter()
+    fields.foreach(converter.acceptField)
+    converter.result
+  }
+}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/ColumnShaper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/ColumnShaper.scala
@@ -10,6 +10,7 @@ case class ColumnShaper(tensorShape: TensorShape) {
   def apply(data: Seq[JsValue]): JsValue = {
     tensorShape match {
       case AnyDims() => data.headOption.getOrElse(JsObject.empty)
+      case Dims(dims, _) if dims.isEmpty => data.headOption.getOrElse(JsObject.empty)
       case Dims(dims, _) =>
         val reverseDims = dims.reverseIterator
         shapeGrouped(JsArray(data.toVector), reverseDims)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/ColumnShaper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/ColumnShaper.scala
@@ -1,17 +1,18 @@
 package io.hydrosphere.serving.manager.model.api.json
 
 import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.{AnyDims, Dims}
 import spray.json.{JsArray, JsObject, JsValue}
 
 import scala.annotation.tailrec
 
-case class ColumnShaper(tensorShapeProto: TensorShape) {
+case class ColumnShaper(tensorShape: TensorShape) {
   def apply(data: Seq[JsValue]): JsValue = {
-    tensorShapeProto.dims match {
-      case Some(shape) =>
-        val dims = shape.reverseIterator
-        shapeGrouped(JsArray(data.toVector), dims)
-      case None => data.headOption.getOrElse(JsObject.empty)
+    tensorShape match {
+      case AnyDims() => data.headOption.getOrElse(JsObject.empty)
+      case Dims(dims, _) =>
+        val reverseDims = dims.reverseIterator
+        shapeGrouped(JsArray(data.toVector), reverseDims)
     }
   }
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/TensorJsonLens.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/json/TensorJsonLens.scala
@@ -4,7 +4,7 @@ import io.hydrosphere.serving.tensorflow.tensor._
 import spray.json.{JsObject, JsValue}
 
 trait TensorJsonLens[T <: TypedTensor[_]]{
-  def convert: (T#Self#DataT) => JsValue
+  def convert: T#Self#DataT => JsValue
   
   final def get(tensor: T): Seq[JsValue] = tensor.data.map(convert)
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/Implicits.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/Implicits.scala
@@ -1,0 +1,8 @@
+package io.hydrosphere.serving.manager.model.api.ops
+
+trait Implicits
+  extends ModelContractOps
+  with ModelSignatureOps
+  with ModelFieldOps {}
+
+object Implicits extends Implicits

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelContractOps.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelContractOps.scala
@@ -1,0 +1,21 @@
+package io.hydrosphere.serving.manager.model.api.ops
+
+import io.hydrosphere.serving.contract.model_contract.ModelContract
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
+
+trait ModelContractOps {
+
+  implicit class ModelContractPumped(modelContract: ModelContract) {
+    def flatten: ContractDescription = {
+      ModelContractOps.flatten(modelContract)
+    }
+  }
+
+  def flatten(modelContract: ModelContract): ContractDescription = {
+    ContractDescription(
+      modelContract.signatures.map(ModelSignatureOps.flatten).toList
+    )
+  }
+}
+
+object ModelContractOps extends ModelContractOps

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelFieldOps.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelFieldOps.scala
@@ -1,0 +1,183 @@
+package io.hydrosphere.serving.manager.model.api.ops
+
+import io.hydrosphere.serving.contract.model_field.ModelField
+import io.hydrosphere.serving.contract.model_field.ModelField.TypeOrSubfields
+import io.hydrosphere.serving.contract.model_field.ModelField.TypeOrSubfields.{Dtype, Empty, Subfields}
+import io.hydrosphere.serving.contract.utils.ContractBuilders
+import io.hydrosphere.serving.manager.model.api.description.FieldDescription
+import io.hydrosphere.serving.manager.model.{HResult, Result}
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.{AnyDims, Dims}
+
+trait ModelFieldOps {
+
+  implicit class ModelFieldPumped(modelField: ModelField) {
+
+    def flatten(rootName: String = ""): Seq[FieldDescription] = {
+      ModelFieldOps.flatten(rootName, modelField)
+    }
+
+    def insert(name: String, fieldInfo: ModelField): Option[ModelField] = {
+      modelField.typeOrSubfields match {
+        case Subfields(fields) =>
+          fields.data.find(_.name == name) match {
+            case Some(_) =>
+              None
+            case None =>
+              val newData = fields.data :+ fieldInfo
+              Some(ContractBuilders.complexField(modelField.name, fieldInfo.shape, newData))
+          }
+        case _ => None
+      }
+    }
+
+    def child(name: String): Option[ModelField] = {
+      modelField.typeOrSubfields match {
+        case Subfields(value) =>
+          value.data.find(_.name == name)
+        case _ => None
+      }
+    }
+
+    def search(name: String): Option[ModelField] = {
+      modelField.typeOrSubfields match {
+        case Subfields(value) =>
+          value.data.find(_.name == name).orElse {
+            value.data.flatMap(_.search(name)).headOption
+          }
+        case _ => None
+      }
+    }
+
+  }
+
+  def mergeAll(inputs: Seq[ModelField], inputs1: Seq[ModelField]): Seq[ModelField] = {
+    (inputs, inputs1) match {
+      case (Nil, x) => x
+      case (x, Nil) => x
+      case (x, y) if x == y => x
+      case _ => inputs.zip(inputs1).flatMap {
+        case (in1, in2) =>
+          if (in1.name == in2.name) {
+            val merged = merge(in1, in2).getOrElse(throw new IllegalArgumentException(s"$in1 and $in2 aren't mergeable"))
+            List(merged)
+          } else {
+            List(in1, in2)
+          }
+      }
+    }
+  }
+
+  def merge(first: ModelField, second: ModelField): Option[ModelField] = {
+    if (first == second) {
+      Some(first)
+    } else if (first.name == second.name) {
+      val res = for {
+        mergedShape <- mergeShapes(TensorShape(first.shape), TensorShape(second.shape)).right
+        mergedType <- mergeTypeOrSubfields(first.typeOrSubfields, second.typeOrSubfields).right
+      } yield {
+        ModelField(first.name, mergedShape.toProto, mergedType)
+      }
+      res.right.toOption
+    } else {
+      None
+    }
+  }
+
+  def mergeShapes(first: TensorShape, second: TensorShape): HResult[TensorShape] = {
+    first -> second match {
+      case (AnyDims(), AnyDims()) => Result.ok(first)
+      case (AnyDims(), Dims(_,_)) => Result.ok(second) // todo maybe reconsider any with dim?
+      case (Dims(_,_), AnyDims()) => Result.ok(first)  // todo maybe reconsider any with dim?
+
+      case (Dims(fDims,_), Dims(sDims,_)) if fDims == sDims => Result.ok(first)
+      case (Dims(fDims,_), Dims(sDims,_)) if fDims.length == sDims.length =>
+        val dims = Result.traverse(fDims.zip(sDims)) {
+          case (fDim, sDim) if fDim == sDim => Result.ok(fDim)
+          case (fDim, sDim) if fDim == -1 => Result.ok(sDim)
+          case (fDim, sDim) if sDim == -1 => Result.ok(fDim)
+          case (fDim, sDim) => Result.clientError(s"Can't merge shape dims: $fDim and $sDim")
+        }
+        dims.right.map(Dims.apply(_))
+
+      case (fd, sd) => Result.clientError(s"Unmergeable shapes: $fd and $sd")
+    }
+  }
+
+  def mergeTypeOrSubfields(first: TypeOrSubfields, second: TypeOrSubfields): HResult[TypeOrSubfields] = {
+    first -> second match {
+      case (fDict: Subfields, sDict: Subfields) =>
+        mergeSubfields(fDict, sDict)
+      case (fInfo: Dtype, sInfo: Dtype) =>
+        mergeTypes(fInfo, sInfo)
+      case (x, y) => Result.clientError(s"Incompatible type combination: $x and $y")
+    }
+  }
+
+  def mergeTypes(first: Dtype, second: Dtype): HResult[Dtype] = {
+    first -> second match {
+      case (Dtype(fInfo), Dtype(sInfo)) if fInfo == sInfo => Result.ok(Dtype(fInfo))
+      case (Dtype(fInfo), Dtype(sInfo)) => Result.clientError(s"Incompatible types: $fInfo and $sInfo")
+    }
+  }
+
+  def mergeSubfields(
+    first: ModelField.TypeOrSubfields.Subfields,
+    second: ModelField.TypeOrSubfields.Subfields
+  ): HResult[ModelField.TypeOrSubfields.Subfields] = {
+    val fields = second.value.data.map { field =>
+      val emitterField = first.value.data.find(_.name == field.name)
+      emitterField.flatMap(merge(_, field))
+    }
+    if (fields.forall(_.isDefined)) {
+      val exactFields = fields.flatten
+      Result.ok(TypeOrSubfields.Subfields(ModelField.Subfield(exactFields)))
+    } else {
+      Result.clientError(s"Subfields aren't mergeable: $first and $second")
+    }
+  }
+
+  def flatten(fields: Seq[ModelField], rootName: String = ""): List[FieldDescription] = {
+    fields.flatMap(flatten(rootName, _)).toList
+  }
+
+  def flatten(rootName: String, field: ModelField): Seq[FieldDescription] = {
+    val name = s"$rootName/${field.name}"
+    val simpleShape = TensorShape(field.shape) match {
+      case AnyDims() => None
+      case Dims(dims, _) => Some(dims)
+    }
+    field.typeOrSubfields match {
+      case Empty => List.empty
+      case Subfields(value) =>
+        value.data.flatMap { subfield =>
+          flatten(name, subfield)
+        }
+      case Dtype(value) =>
+        List(
+          FieldDescription(
+            name,
+            value,
+            simpleShape
+          )
+        )
+    }
+  }
+
+  def appendAll(outputs: Seq[ModelField], inputs: Seq[ModelField]): Option[Seq[ModelField]] = {
+    val fields = inputs.map { input =>
+      outputs.find(_.name == input.name).flatMap { output =>
+        merge(output, input)
+      }
+    }
+
+    if (fields.exists(_.isEmpty)) {
+      None
+    } else {
+      Some(fields.flatten)
+    }
+  }
+
+}
+
+object ModelFieldOps extends ModelFieldOps

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelSignatureOps.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/ops/ModelSignatureOps.scala
@@ -1,0 +1,40 @@
+package io.hydrosphere.serving.manager.model.api.ops
+
+import io.hydrosphere.serving.contract.model_field.ModelField
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.manager.model.api.description.SignatureDescription
+
+trait ModelSignatureOps {
+  def merge(signature1: ModelSignature, signature2: ModelSignature): ModelSignature = {
+    val mergedIns = ModelFieldOps.mergeAll(signature1.inputs, signature2.inputs)
+    val mergedOuts = ModelFieldOps.mergeAll(signature1.outputs, signature2.outputs)
+    ModelSignature(
+      s"${signature1.signatureName}&${signature2.signatureName}",
+      mergedIns,
+      mergedOuts
+    )
+  }
+
+  def flatten(modelSignature: ModelSignature): SignatureDescription = {
+    val inputs = ModelFieldOps.flatten(modelSignature.inputs)
+    val outputs = ModelFieldOps.flatten(modelSignature.outputs)
+    SignatureDescription(modelSignature.signatureName, inputs, outputs)
+  }
+
+  def append(head: ModelSignature, tail: ModelSignature): Option[ModelSignature] = {
+    if (tail.inputs.isEmpty) {
+      None
+    } else {
+      val maybeFields: Option[Seq[ModelField]] = ModelFieldOps.appendAll(head.outputs, tail.inputs)
+      maybeFields.map { _ =>
+        ModelSignature(
+          s"${head.signatureName}>${tail.signatureName}",
+          head.inputs,
+          tail.outputs
+        )
+      }
+    }
+  }
+}
+
+object ModelSignatureOps extends ModelSignatureOps

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ComplexFieldBuilder.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ComplexFieldBuilder.scala
@@ -22,7 +22,7 @@ class ComplexFieldBuilder(val modelField: ModelField, val subfields: Seq[ModelFi
           Right(
             MapTensor(
               TensorShape.fromProto(modelField.shape),
-              results.map(_.data.head) // since we know that submaps are NONE shape
+              results.map(_.data.head)
             )
           )
         }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ComplexFieldBuilder.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ComplexFieldBuilder.scala
@@ -1,7 +1,7 @@
 package io.hydrosphere.serving.manager.model.api.tensor_builder
 
 import io.hydrosphere.serving.contract.model_field.ModelField
-import io.hydrosphere.serving.contract.utils.validation.{FieldMissingError, IncompatibleFieldTypeError, ValidationError}
+import io.hydrosphere.serving.manager.model.api.validation.{FieldMissingError, IncompatibleFieldTypeError, ValidationError}
 import io.hydrosphere.serving.tensorflow.TensorShape
 import io.hydrosphere.serving.tensorflow.tensor.MapTensor
 import io.hydrosphere.serving.tensorflow.types.DataType
@@ -21,7 +21,7 @@ class ComplexFieldBuilder(val modelField: ModelField, val subfields: Seq[ModelFi
           val results = eithers.map(_.right.get)
           Right(
             MapTensor(
-              TensorShape.fromProto(modelField.shape),
+              TensorShape(modelField.shape),
               results.map(_.data.head)
             )
           )
@@ -46,7 +46,7 @@ class ComplexFieldBuilder(val modelField: ModelField, val subfields: Seq[ModelFi
           val tensors = a.collect { case Right((name, tensor)) => name -> tensor }.toMap
           Right(
             MapTensor(
-              TensorShape.fromProto(modelField.shape),
+              TensorShape(modelField.shape),
               Seq(tensors)
             )
           )

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/InfoFieldBuilder.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/InfoFieldBuilder.scala
@@ -1,7 +1,7 @@
 package io.hydrosphere.serving.manager.model.api.tensor_builder
 
 import io.hydrosphere.serving.contract.model_field.ModelField
-import io.hydrosphere.serving.contract.utils.validation._
+import io.hydrosphere.serving.manager.model.api.validation.{IncompatibleFieldTypeError, ValidationError}
 import io.hydrosphere.serving.tensorflow.TensorShape
 import io.hydrosphere.serving.tensorflow.tensor._
 import io.hydrosphere.serving.tensorflow.types.DataType
@@ -43,7 +43,7 @@ class InfoFieldBuilder(val field: ModelField, val dataType: DataType) {
   }
 
   def toTensor[T <: TypedTensor[_]](factory: TypedTensorFactory[T], flatData: Seq[Any]): Either[ValidationError, T] = {
-    factory.createFromAny(flatData, TensorShape.fromProto(field.shape)) match {
+    factory.createFromAny(flatData, TensorShape(field.shape)) match {
       case Some(tensor) => Right(tensor)
       case None => Left(new ValidationError(s"Can't create a tensor with $dataType type and ${field.shape} shape for [$flatData]") {})
     }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ModelFieldBuilder.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/ModelFieldBuilder.scala
@@ -2,7 +2,7 @@ package io.hydrosphere.serving.manager.model.api.tensor_builder
 
 import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.contract.model_field.ModelField.TypeOrSubfields._
-import io.hydrosphere.serving.contract.utils.validation.{ComplexFieldValidationError, ValidationError}
+import io.hydrosphere.serving.manager.model.api.validation.{ComplexFieldValidationError, ValidationError}
 import io.hydrosphere.serving.tensorflow.tensor.TypedTensor
 import spray.json.JsValue
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/SignatureBuilder.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/tensor_builder/SignatureBuilder.scala
@@ -2,7 +2,7 @@ package io.hydrosphere.serving.manager.model.api.tensor_builder
 
 import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
-import io.hydrosphere.serving.contract.utils.validation.{SignatureValidationError, ValidationError}
+import io.hydrosphere.serving.manager.model.api.validation.{SignatureValidationError, ValidationError}
 import io.hydrosphere.serving.tensorflow.tensor.TypedTensor
 import spray.json.JsObject
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/validation/package.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/validation/package.scala
@@ -1,0 +1,44 @@
+package io.hydrosphere.serving.manager.model.api
+
+import io.hydrosphere.serving.contract.model_contract.ModelContract
+import io.hydrosphere.serving.contract.model_field.ModelField
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.manager.model.Result.HError
+import io.hydrosphere.serving.tensorflow.tensor_shape.TensorShapeProto
+import io.hydrosphere.serving.tensorflow.types.DataType
+
+package object validation {
+  abstract class ValidationError(val message: String) extends HError
+
+  class SignatureMissingError(val expectedSignature: String, val modelContract: ModelContract)
+    extends ValidationError(
+      s"Couldn't find '$expectedSignature' signature among [${modelContract.signatures.map(_.signatureName)}] signatures"
+    ) {}
+
+  class SignatureValidationError(
+    val suberrors: Seq[ValidationError],
+    val modelSignature: ModelSignature
+  ) extends ValidationError(
+      s"Errors while validating data for '${modelSignature.signatureName}' signature: ${suberrors.mkString("\n")}"
+    ) {}
+
+  class FieldMissingError(val expectedField: String)
+    extends ValidationError(s"Couldn't find '$expectedField' field") {}
+
+  class ComplexFieldValidationError(val suberrors: Seq[ValidationError], val field: ModelField)
+    extends ValidationError(
+      s"Errors while validating subfields for '${field.name}' field: ${suberrors.mkString("\n")}"
+    )
+
+  class IncompatibleFieldTypeError(val field: String, val expectedType: DataType)
+    extends ValidationError(s"'$field' got data with incompatible type, expected $expectedType")
+
+  class UnsupportedFieldTypeError(val expectedType: DataType)
+    extends ValidationError(s"'$expectedType' is not supported")
+
+  class IncompatibleFieldShapeError(val field: String, val expectedShape: Option[TensorShapeProto])
+    extends ValidationError(s"'$field' got data with incompatible shape, expected $expectedShape")
+
+  class InvalidFieldData[T](val actualClass: Class[T])
+    extends ValidationError(s"Got data with incompatible type '$actualClass'")
+}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/validation/package.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/api/validation/package.scala
@@ -19,7 +19,7 @@ package object validation {
     val suberrors: Seq[ValidationError],
     val modelSignature: ModelSignature
   ) extends ValidationError(
-      s"Errors while validating data for '${modelSignature.signatureName}' signature: ${suberrors.mkString("\n")}"
+      s"Errors while validating data for '${modelSignature.signatureName}' signature: ${suberrors.map(_.message).mkString("\n")}"
     ) {}
 
   class FieldMissingError(val expectedField: String)
@@ -27,7 +27,7 @@ package object validation {
 
   class ComplexFieldValidationError(val suberrors: Seq[ValidationError], val field: ModelField)
     extends ValidationError(
-      s"Errors while validating subfields for '${field.name}' field: ${suberrors.mkString("\n")}"
+      s"Errors while validating subfields for '${field.name}' field: ${suberrors.map(_.message).mkString("\n")}"
     )
 
   class IncompatibleFieldTypeError(val field: String, val expectedType: DataType)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/model/protocol/ContractJsonProtocol.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/model/protocol/ContractJsonProtocol.scala
@@ -2,7 +2,7 @@ package io.hydrosphere.serving.manager.model.protocol
 
 import io.hydrosphere.serving.contract.model_contract.ModelContract
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
-import io.hydrosphere.serving.contract.utils.description.{ContractDescription, FieldDescription, SignatureDescription}
+import io.hydrosphere.serving.manager.model.api.description.{ContractDescription, FieldDescription, SignatureDescription}
 import io.hydrosphere.serving.tensorflow.types.DataType
 import spray.json.{DeserializationException, JsString, JsValue, JsonFormat}
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/application/ApplicationManagementServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/application/ApplicationManagementServiceImpl.scala
@@ -23,6 +23,7 @@ import io.hydrosphere.serving.manager.service.clouddriver.CloudDriverService
 import io.hydrosphere.serving.manager.service.internal_events.InternalManagerEventsPublisher
 import io.hydrosphere.serving.manager.service.model_version.ModelVersionManagementService
 import io.hydrosphere.serving.manager.service.service.{CreateServiceRequest, ServiceManagementService}
+import io.hydrosphere.serving.manager.util.TensorUtil
 import io.hydrosphere.serving.monitoring.monitoring.ExecutionInformation.ResponseOrError
 import io.hydrosphere.serving.monitoring.monitoring.{ExecutionError, ExecutionInformation, ExecutionMetadata, MonitoringServiceGrpc}
 import io.hydrosphere.serving.tensorflow.api.model.ModelSpec
@@ -113,61 +114,83 @@ class ApplicationManagementServiceImpl(
   }
 
 
-  def serve(unit: ExecutionUnit, request: PredictRequest, tracingInfo: Option[RequestTracingInfo]): Future[PredictResponse] = {
-    val modelVersionIdHeaderValue = new AtomicReference[String](null)
-    val latencyHeaderValue = new AtomicReference[String](null)
-
-    var requestBuilder = grpcClient
-      .withOption(AuthorityReplacerInterceptor.DESTINATION_KEY, unit.serviceName)
-      .withOption(Headers.XServingModelVersionId.callOptionsClientResponseWrapperKey, modelVersionIdHeaderValue)
-      .withOption(Headers.XEnvoyUpstreamServiceTime.callOptionsClientResponseWrapperKey, latencyHeaderValue)
-
-    if (tracingInfo.isDefined) {
-      val tr = tracingInfo.get
-      requestBuilder = requestBuilder
-        .withOption(Headers.XRequestId.callOptionsKey, tr.xRequestId)
-
-      if (tr.xB3requestId.isDefined) {
-        requestBuilder = requestBuilder
-          .withOption(Headers.XB3TraceId.callOptionsKey, tr.xB3requestId.get)
-      }
-
-      if (tr.xB3SpanId.isDefined) {
-        requestBuilder = requestBuilder
-          .withOption(Headers.XB3ParentSpanId.callOptionsKey, tr.xB3SpanId.get)
-      }
+  def serve(unit: ExecutionUnit, request: PredictRequest, tracingInfo: Option[RequestTracingInfo]): HFResult[PredictResponse] = {
+    val verificationResults = request.inputs.map {
+      case (name, tensor) => name -> TensorUtil.verifyShape(tensor)
     }
 
-    requestBuilder
-      .predict(request)
-      .transform(
-        response => {
-          val latency = getLatency(latencyHeaderValue)
-          val res = if (latency.isSuccess) {
-            response.addInternalInfo(
-              "system.latency" -> latency.get
-            )
-          } else {
-            response
-          }
+    val errors = verificationResults.filter {
+      case (_, t) => t.isLeft
+    }.mapValues(_.left.get)
 
-          sendToDebug(ResponseOrError.Response(res), request, getCurrentExecutionUnit(unit, modelVersionIdHeaderValue))
-          response
-        },
-        thr => {
-          logger.error("Can't send message to GATEWAY_KAFKA", thr)
-          sendToDebug(ResponseOrError.Error(ExecutionError(thr.toString)), request, getCurrentExecutionUnit(unit, modelVersionIdHeaderValue))
-          thr
+    if (errors.isEmpty) {
+      val modelVersionIdHeaderValue = new AtomicReference[String](null)
+      val latencyHeaderValue = new AtomicReference[String](null)
+
+      var requestBuilder = grpcClient
+        .withOption(AuthorityReplacerInterceptor.DESTINATION_KEY, unit.serviceName)
+        .withOption(Headers.XServingModelVersionId.callOptionsClientResponseWrapperKey, modelVersionIdHeaderValue)
+        .withOption(Headers.XEnvoyUpstreamServiceTime.callOptionsClientResponseWrapperKey, latencyHeaderValue)
+
+      if (tracingInfo.isDefined) {
+        val tr = tracingInfo.get
+        requestBuilder = requestBuilder
+          .withOption(Headers.XRequestId.callOptionsKey, tr.xRequestId)
+
+        if (tr.xB3requestId.isDefined) {
+          requestBuilder = requestBuilder
+            .withOption(Headers.XB3TraceId.callOptionsKey, tr.xB3requestId.get)
         }
+
+        if (tr.xB3SpanId.isDefined) {
+          requestBuilder = requestBuilder
+            .withOption(Headers.XB3ParentSpanId.callOptionsKey, tr.xB3SpanId.get)
+        }
+      }
+
+      val verifiedInputs = verificationResults.mapValues(_.right.get)
+      val verifiedRequest = request.copy(inputs = verifiedInputs)
+
+      requestBuilder
+        .predict(verifiedRequest)
+        .transform(
+          response => {
+            val latency = getLatency(latencyHeaderValue)
+            val res = if (latency.isSuccess) {
+              response.addInternalInfo(
+                "system.latency" -> latency.get
+              )
+            } else {
+              response
+            }
+
+            sendToDebug(ResponseOrError.Response(res), verifiedRequest, getCurrentExecutionUnit(unit, modelVersionIdHeaderValue))
+            Result.ok(response)
+          },
+          thr => {
+            logger.error("Can't send message to GATEWAY_KAFKA", thr)
+            sendToDebug(ResponseOrError.Error(ExecutionError(thr.toString)), verifiedRequest, getCurrentExecutionUnit(unit, modelVersionIdHeaderValue))
+            thr
+          }
+        )
+    } else {
+      Future.successful(
+        Result.errors(
+          errors.map {
+            case (name, err) =>
+              ClientError(s"Shape verification error for input $name: $err")
+          }.toSeq
+        )
       )
+    }
   }
 
-  def servePipeline(units: Seq[ExecutionUnit], data: PredictRequest, tracingInfo: Option[RequestTracingInfo]): Future[PredictResponse] = {
+  def servePipeline(units: Seq[ExecutionUnit], data: PredictRequest, tracingInfo: Option[RequestTracingInfo]): HFResult[PredictResponse] = {
     //TODO Add request id for step
-    val empty = Future.successful(PredictResponse(outputs = data.inputs))
+    val empty = Result.okF(PredictResponse(outputs = data.inputs))
     units.foldLeft(empty) {
       case (a, b) =>
-        a.flatMap { resp =>
+        EitherT(a).flatMap { resp =>
           val request = PredictRequest(
             modelSpec = Some(
               ModelSpec(
@@ -176,8 +199,8 @@ class ApplicationManagementServiceImpl(
             ),
             inputs = resp.outputs
           )
-          serve(b, request, tracingInfo)
-        }
+          EitherT(serve(b, request, tracingInfo))
+        }.value
     }
   }
 
@@ -205,7 +228,7 @@ class ApplicationManagementServiceImpl(
               servicePath = servicePath.signatureName,
               stageInfo = stageInfo
             )
-            serve(unit, request, tracingInfo).map(Result.ok)
+            serve(unit, request, tracingInfo)
           case None => Result.clientErrorF("ModelSpec in request is not specified")
         }
       case stages => // pipeline
@@ -238,7 +261,7 @@ class ApplicationManagementServiceImpl(
         Result.sequence(execUnits) match {
           case Left(err) => Result.errorF(err)
           case Right(units) =>
-            servePipeline(units, request, tracingInfo).map(Result.ok)
+            servePipeline(units, request, tracingInfo)
         }
     }
   }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/application/ApplicationManagementServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/application/ApplicationManagementServiceImpl.scala
@@ -6,14 +6,14 @@ import cats.data.EitherT
 import cats.implicits._
 import io.hydrosphere.serving.contract.model_contract.ModelContract
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
-import io.hydrosphere.serving.contract.utils.DataGenerator
-import io.hydrosphere.serving.contract.utils.ops.ModelSignatureOps
 import io.hydrosphere.serving.grpc.{AuthorityReplacerInterceptor, Header, Headers}
 import io.hydrosphere.serving.manager.ApplicationConfig
 import io.hydrosphere.serving.manager.controller.application._
 import io.hydrosphere.serving.manager.model.Result.ClientError
 import io.hydrosphere.serving.manager.model.Result.Implicits._
+import io.hydrosphere.serving.manager.model.api.TensorExampleGenerator
 import io.hydrosphere.serving.manager.model.api.json.TensorJsonLens
+import io.hydrosphere.serving.manager.model.api.ops.ModelSignatureOps
 import io.hydrosphere.serving.manager.model.api.tensor_builder.SignatureBuilder
 import io.hydrosphere.serving.manager.model.db._
 import io.hydrosphere.serving.manager.model.{db, _}
@@ -418,7 +418,7 @@ class ApplicationManagementServiceImpl(
       result.right.flatMap { app =>
         app.contract.signatures.find(_.signatureName == signatureName) match {
           case Some(signature) =>
-            val data = DataGenerator(signature).generateInputs
+            val data = TensorExampleGenerator(signature).inputs
             Result.ok(TensorJsonLens.mapToJson(data))
           case None => Result.clientError(s"Can't find signature '$signatureName")
         }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/contract/ContractUtilityServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/contract/ContractUtilityServiceImpl.scala
@@ -1,15 +1,15 @@
 package io.hydrosphere.serving.manager.service.contract
 
 import io.hydrosphere.serving.contract.model_contract.ModelContract
-import io.hydrosphere.serving.contract.utils.DataGenerator
+import io.hydrosphere.serving.manager.model.api.TensorExampleGenerator
 import io.hydrosphere.serving.manager.model.api.json.TensorJsonLens
 import io.hydrosphere.serving.manager.model.{HResult, Result}
 import spray.json.JsObject
 
 class ContractUtilityServiceImpl extends ContractUtilityService {
   def generatePayload(contract: ModelContract, signature: String): HResult[JsObject] = {
-    DataGenerator.forContract(contract, signature) match {
-      case Some(generator) => Result.ok(TensorJsonLens.mapToJson(generator.generateInputs))
+    TensorExampleGenerator.forContract(contract, signature) match {
+      case Some(generator) => Result.ok(TensorJsonLens.mapToJson(generator.inputs))
       case None => Result.clientError(s"Can't find '$signature' signature in contract")
     }
   }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model/ModelManagementService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model/ModelManagementService.scala
@@ -1,8 +1,8 @@
 package io.hydrosphere.serving.manager.service.model
 
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
 import io.hydrosphere.serving.manager.controller.model.{ModelUpload, UploadedEntity}
 import io.hydrosphere.serving.manager.model._
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import io.hydrosphere.serving.manager.model.db.Model
 import spray.json.JsObject
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model/ModelManagementServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model/ModelManagementServiceImpl.scala
@@ -3,8 +3,7 @@ package io.hydrosphere.serving.manager.service.model
 import java.time.LocalDateTime
 
 import io.hydrosphere.serving.contract.model_contract.ModelContract
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
-import io.hydrosphere.serving.contract.utils.ops.ModelContractOps._
+import io.hydrosphere.serving.manager.model.api.ops.ModelContractOps._
 import io.hydrosphere.serving.manager.controller.model.ModelUpload
 import io.hydrosphere.serving.manager.model._
 import io.hydrosphere.serving.manager.model.api.ModelType
@@ -15,6 +14,7 @@ import io.hydrosphere.serving.manager.service.source.ModelStorageService
 import cats.data.EitherT
 import cats.implicits._
 import io.hydrosphere.serving.manager.model.Result.HError
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import org.apache.logging.log4j.scala.Logging
 import spray.json.JsObject
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/BuildModelRequest.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/BuildModelRequest.scala
@@ -1,6 +1,6 @@
 package io.hydrosphere.serving.manager.service.model_build
 
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 
 case class BuildModelRequest (
   modelId: Long,

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/ModelBuildManagementServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/ModelBuildManagementServiceImpl.scala
@@ -4,7 +4,6 @@ import java.time.LocalDateTime
 
 import cats.data.EitherT
 import cats.implicits._
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
 import io.hydrosphere.serving.manager.controller.model.ModelUpload
 import io.hydrosphere.serving.manager.model.Result.{ClientError, HError}
 import io.hydrosphere.serving.manager.model._
@@ -16,6 +15,7 @@ import io.hydrosphere.serving.manager.service.model.ModelManagementService
 import io.hydrosphere.serving.manager.service.model_version.ModelVersionManagementService
 import org.apache.logging.log4j.scala.Logging
 import Result.Implicits._
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import io.hydrosphere.serving.manager.util.docker.{HistoricProgressHandler, InfoProgressHandler}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/ModelBuildManagmentService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_build/ModelBuildManagmentService.scala
@@ -1,6 +1,5 @@
 package io.hydrosphere.serving.manager.service.model_build
 
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
 import io.hydrosphere.serving.manager.controller.model.ModelUpload
 import io.hydrosphere.serving.manager.model._
 import io.hydrosphere.serving.manager.model.db.{ModelBuild, ModelVersion}

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_version/ModelVersionManagementService.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_version/ModelVersionManagementService.scala
@@ -1,7 +1,7 @@
 package io.hydrosphere.serving.manager.service.model_version
 
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
 import io.hydrosphere.serving.manager.model.HFResult
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import io.hydrosphere.serving.manager.model.db.ModelVersion
 import spray.json.JsObject
 

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_version/ModelVersionManagementServiceImpl.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/model_version/ModelVersionManagementServiceImpl.scala
@@ -2,9 +2,9 @@ package io.hydrosphere.serving.manager.service.model_version
 
 import cats.data.EitherT
 import cats.implicits._
-import io.hydrosphere.serving.contract.utils.description.ContractDescription
-import io.hydrosphere.serving.contract.utils.ops.ModelContractOps._
+import io.hydrosphere.serving.manager.model.api.ops.ModelContractOps._
 import io.hydrosphere.serving.manager.model.Result.HError
+import io.hydrosphere.serving.manager.model.api.description.ContractDescription
 import io.hydrosphere.serving.manager.model.db.ModelVersion
 import io.hydrosphere.serving.manager.model.{HFResult, Result}
 import io.hydrosphere.serving.manager.repository.ModelVersionRepository

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/TensorflowModelFetcher.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/TensorflowModelFetcher.scala
@@ -50,7 +50,7 @@ object TensorflowModelFetcher extends ModelFetcher with Logging {
       Some(TensorShapeProto(tShape.getDimList.map(x => TensorShapeProto.Dim(x.getSize, x.getName)), tShape.getUnknownRank))
     } else None
     val convertedDtype = DataType.fromValue(tensorInfo.getDtypeValue)
-    FieldInfo(convertedDtype, TensorShape.fromProto(shape))
+    FieldInfo(convertedDtype, TensorShape(shape))
   }
 
   private def convertTensorMap(tensorMap: Map[String, TensorInfo]): List[ModelField] = {

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/spark/mappers/Feature.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/spark/mappers/Feature.scala
@@ -6,6 +6,7 @@ import io.hydrosphere.serving.tensorflow.types.DataType
 import io.hydrosphere.serving.tensorflow.types.DataType.{DT_DOUBLE, DT_STRING, DT_VARIANT}
 import io.hydrosphere.serving.manager.service.source.fetchers.spark.SparkModelMetadata
 import io.hydrosphere.serving.manager.service.source.fetchers.spark.mappers.SparkMlTypeMapper._
+import io.hydrosphere.serving.tensorflow.TensorShape.AnyDims
 
 class HashingTFMapper(m: SparkModelMetadata)  extends InputOutputMapper(m) {
   override def inputType(sparkModelMetadata: SparkModelMetadata) = varVec(DT_STRING)
@@ -128,7 +129,7 @@ class VectorAssemblerMapper(m: SparkModelMetadata)  extends SparkMlTypeMapper(m)
     m.getParam[Seq[String]]("inputCols")
       .map{
         _.map{ col =>
-          ContractBuilders.simpleTensorModelField(col, DT_VARIANT, Some(Seq.empty), unknownRank = true)
+          ContractBuilders.simpleTensorModelField(col, DT_VARIANT, AnyDims())
         }
       }
       .getOrElse(

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/spark/mappers/UntypedMapper.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/source/fetchers/spark/mappers/UntypedMapper.scala
@@ -4,6 +4,7 @@ import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.contract.utils.ContractBuilders
 import io.hydrosphere.serving.tensorflow.types.DataType
 import io.hydrosphere.serving.manager.service.source.fetchers.spark.SparkModelMetadata
+import io.hydrosphere.serving.tensorflow.TensorShape.AnyDims
 
 class UntypedMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(m) {
   private[this] val inputCols = Array("inputCol", "featuresCol")
@@ -16,7 +17,7 @@ class UntypedMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(m) {
         ContractBuilders.simpleTensorModelField(
           label,
           DataType.DT_STRING,
-          None
+          AnyDims()
         )
       }
   }
@@ -30,8 +31,7 @@ class UntypedMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(m) {
             ContractBuilders.simpleTensorModelField(
               inputName,
               DataType.DT_STRING,
-              Some(Seq.empty),
-              unknownRank = true
+              AnyDims()
             )
         }
       }
@@ -47,8 +47,7 @@ class UntypedMapper(m: SparkModelMetadata) extends SparkMlTypeMapper(m) {
             ContractBuilders.simpleTensorModelField(
               inputName,
               DataType.DT_STRING,
-              Some(Seq.empty),
-              unknownRank = true
+              AnyDims()
             )
         }
       }

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/util/TensorUtil.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/util/TensorUtil.scala
@@ -1,15 +1,15 @@
 package io.hydrosphere.serving.manager.util
 
 import io.hydrosphere.serving.manager.model.{HResult, Result}
-import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.{AnyDims, Dims}
 import io.hydrosphere.serving.tensorflow.tensor.{TensorProto, TypedTensor, TypedTensorFactory}
 
 object TensorUtil {
   def verifyShape[T](tensor: TypedTensor[T]): HResult[TypedTensor[T]] = {
-    tensor.shape.dims match {
-      case Some(Nil) => Result.ok(tensor)
-      case None => Result.ok(tensor)
-      case Some(tensorDims) =>
+    tensor.shape match {
+      case AnyDims() => Result.ok(tensor)
+      case Dims(tensorDims, _) if tensorDims.isEmpty => Result.ok(tensor)
+      case Dims(tensorDims, _) =>
         if (tensorDims.isEmpty && tensor.data.length <= 1) {
           Result.ok(tensor)
         } else {
@@ -38,7 +38,7 @@ object TensorUtil {
           }
 
           if (isShapeOk) {
-            val rawTensor = tensor.toProto.copy(tensorShape = TensorShape.fromSeq(Some(actualDims)).toProto)
+            val rawTensor = tensor.toProto.copy(tensorShape = Dims(actualDims).toProto)
             val result = tensor.factory.fromProto(rawTensor)
             Result.ok(result)
           } else {

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/util/TensorUtil.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/util/TensorUtil.scala
@@ -1,0 +1,67 @@
+package io.hydrosphere.serving.manager.util
+
+import io.hydrosphere.serving.manager.model.{HResult, Result}
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.tensor.{TensorProto, TypedTensor, TypedTensorFactory}
+
+object TensorUtil {
+  def verifyShape[T](tensor: TensorProto): HResult[TensorProto] = {
+    val ttensor = TypedTensorFactory.create(tensor)
+    val data = ttensor.data.toArray
+    if (ttensor.shape.dims.isEmpty && data.length <= 1) { // allow empty scalar tensors?
+      Result.ok(tensor)
+    } else {
+      val dims = ttensor.shape.dims.get.reverseIterator
+
+      val actualDims = new Array[Long](dims.length)
+      var actualDimId = actualDims.length
+      var dimDataLen = data.length
+
+      var isShapeOk = true
+
+      // test cases
+
+      // [-1, 2, 3]
+
+      // a b c d e f g h k l - 10
+      // 1. 10 % 3 != 0
+      // 2. Fail
+
+      // a b c d e f g h k - 9
+      // 1. 9 % 3 == 0; 9 / 3 == 3
+      // 2. 3 % 2 != 0
+      // 3. Fail
+
+      // a b c d e f g - 6
+      // 1. 6 % 3 == 0; 6 / 3 == 2
+      // 2. 2 % 2 == 0; 2 / 2 == 1
+      // 3. 1 % x == 0
+      // 4. ok
+
+      // a b c d e f g h k l q w - 12
+      // 1. 12 % 3 == 0; 12 / 3 == 4
+      // 2. 4 % 2 == 0; 4 / 2 == 2
+      // 3. 2 % x == 0
+      // 4. ok
+
+      while (isShapeOk && dims.hasNext) {
+        val currentDim = dims.next()
+        val subCount = dimDataLen.toDouble / currentDim.toDouble
+        if (subCount.isWhole()) { // ok
+          dimDataLen = subCount.toInt
+          actualDims(actualDimId) = dimDataLen
+          actualDimId -= 1
+        } else { // not ok
+          isShapeOk = false
+        }
+      }
+
+      if (isShapeOk) {
+        Result.clientError(s"Invalid shape ${ttensor.shape.dims} for data $data")
+      } else {
+        val trueShapedTensor = tensor.copy(tensorShape = TensorShape.fromSeq(Some(actualDims)).toProto)
+        Result.ok(trueShapedTensor)
+      }
+    }
+  }
+}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ContractOpsSpecs.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ContractOpsSpecs.scala
@@ -1,0 +1,348 @@
+package io.hydrosphere.serving.manager.model.api
+
+import io.hydrosphere.serving.contract.model_contract.ModelContract
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.contract.utils.ContractBuilders
+import io.hydrosphere.serving.manager.model.api.description.{ContractDescription, FieldDescription, SignatureDescription}
+import io.hydrosphere.serving.manager.model.api.ops.ModelSignatureOps
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.types.DataType
+import org.scalatest.WordSpec
+
+
+class ContractOpsSpecs extends WordSpec {
+
+  import io.hydrosphere.serving.manager.model.api.ops.Implicits._
+
+  "ContractOps" can {
+    "merge" should {
+      "success" when {
+        "empty and non-empty" in {
+          val sig1 = ModelSignature(
+            "sig1",
+            List.empty,
+            List.empty
+          )
+          val sig2 = ModelSignature(
+            "sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          val expectedSig = ModelSignature(
+            "sig1&sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          assert(ModelSignatureOps.merge(sig1, sig2) === expectedSig)
+        }
+
+        "signatures don't overlap" in {
+          val sig1 = ModelSignature(
+            "sig1",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+            )
+          )
+          val sig2 = ModelSignature(
+            "sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          val expectedSig = ModelSignature(
+            "sig1&sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar),
+              ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1)),
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          assert(ModelSignatureOps.merge(sig1, sig2) === expectedSig)
+        }
+
+        "inputs are overlapping and compatible" in {
+          val sig1 = ModelSignature(
+            "sig1",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, TensorShape.vector(-1))
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+            )
+          )
+          val sig2 = ModelSignature(
+            "sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, TensorShape.vector(3))
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          val expectedSig = ModelSignature(
+            "sig1&sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, TensorShape.vector(3))
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1)),
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          assert(ModelSignatureOps.merge(sig1, sig2) === expectedSig)
+        }
+      }
+
+      "fail" when {
+        "inputs overlap is conflicting" in {
+          val sig1 = ModelSignature(
+            "sig1",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+            )
+          )
+          val sig2 = ModelSignature(
+            "sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          assertThrows[IllegalArgumentException](ModelSignatureOps.merge(sig1, sig2))
+        }
+
+        "outputs overlap is conflicting" in {
+          val sig1 = ModelSignature(
+            "sig1",
+            List(
+              ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+            )
+          )
+          val sig2 = ModelSignature(
+            "sig2",
+            List(
+              ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+            ),
+            List(
+              ContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, TensorShape.vector(3))
+            )
+          )
+
+          assertThrows[IllegalArgumentException](ModelSignatureOps.merge(sig1, sig2))
+        }
+      }
+    }
+
+    "flatten" when {
+      "contract is flat" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+          )
+        )
+        val contract = ModelContract("test", Seq(sig1, sig2))
+
+        val expected = ContractDescription(
+          List(
+            SignatureDescription(
+              "sig1",
+              inputs = List(
+                FieldDescription("/in1", DataType.DT_STRING, None)
+              ),
+              outputs = List(
+                FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
+              )
+            ),
+            SignatureDescription(
+              "sig2",
+              inputs = List(
+                FieldDescription("/in2", DataType.DT_INT32, None)
+              ),
+              outputs = List(
+                FieldDescription("/out2", DataType.DT_INT32, Some(List(3)))
+              )
+            )
+          )
+        )
+
+        assert(contract.flatten === expected)
+      }
+
+      "contract is nested" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.complexField(
+              "in",
+              None,
+              Seq(
+                ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+              )
+            )
+          ),
+          List(
+            ContractBuilders.complexField(
+              "out",
+              None,
+              Seq(
+                ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1)),
+                ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.scalar)
+              )
+            )
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(3))
+          )
+        )
+        val contract = ModelContract("test", Seq(sig1, sig2))
+
+        val expected = ContractDescription(
+          List(
+            SignatureDescription(
+              "sig1",
+              inputs = List(
+                FieldDescription("/in/in1", DataType.DT_STRING, None),
+                FieldDescription("/in/in2", DataType.DT_INT32, None)
+              ),
+              outputs = List(
+                FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
+                FieldDescription("/out/out2", DataType.DT_INT32, None)
+              )
+            ),
+            SignatureDescription(
+              "sig2",
+              inputs = List(
+                FieldDescription("/in2", DataType.DT_INT32, None)
+              ),
+              outputs = List(
+                FieldDescription("/out2", DataType.DT_INT32, Some(List(3)))
+              )
+            )
+          )
+        )
+
+        assert(contract.flatten === expected)
+      }
+    }
+
+    "unflatten" when {
+      "non-nested contract" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+
+        val flatSignature = SignatureDescription(
+          "sig1",
+          inputs = List(
+            FieldDescription("/in1", DataType.DT_STRING, None)
+          ),
+          outputs = List(
+            FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
+          )
+        )
+
+        assert(SignatureDescription.toSignature(flatSignature) === sig1)
+      }
+      "contract is nested" in {
+        val signature = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.complexField(
+              "in",
+              None,
+              Seq(
+                ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.scalar)
+              )
+            )
+          ),
+          List(
+            ContractBuilders.complexField(
+              "out",
+              None,
+              Seq(
+                ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1)),
+                ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.scalar)
+              )
+            )
+          )
+        )
+
+        val signatureDescription = SignatureDescription(
+          "sig1",
+          inputs = List(
+            FieldDescription("/in/in1", DataType.DT_STRING, None),
+            FieldDescription("/in/in2", DataType.DT_INT32, None)
+          ),
+          outputs = List(
+            FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
+            FieldDescription("/out/out2", DataType.DT_INT32, None)
+          )
+        )
+
+        val restored = SignatureDescription.toSignature(signatureDescription)
+
+        assert(restored === signature)
+      }
+    }
+
+  }
+}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ContractOpsSpecs.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ContractOpsSpecs.scala
@@ -192,7 +192,7 @@ class ContractOpsSpecs extends WordSpec {
             SignatureDescription(
               "sig1",
               inputs = List(
-                FieldDescription("/in1", DataType.DT_STRING, None)
+                FieldDescription("/in1", DataType.DT_STRING, Some(Seq.empty))
               ),
               outputs = List(
                 FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
@@ -201,7 +201,7 @@ class ContractOpsSpecs extends WordSpec {
             SignatureDescription(
               "sig2",
               inputs = List(
-                FieldDescription("/in2", DataType.DT_INT32, None)
+                FieldDescription("/in2", DataType.DT_INT32, Some(Seq.empty))
               ),
               outputs = List(
                 FieldDescription("/out2", DataType.DT_INT32, Some(List(3)))
@@ -253,18 +253,18 @@ class ContractOpsSpecs extends WordSpec {
             SignatureDescription(
               "sig1",
               inputs = List(
-                FieldDescription("/in/in1", DataType.DT_STRING, None),
-                FieldDescription("/in/in2", DataType.DT_INT32, None)
+                FieldDescription("/in/in1", DataType.DT_STRING, Some(Seq.empty)),
+                FieldDescription("/in/in2", DataType.DT_INT32, Some(Seq.empty))
               ),
               outputs = List(
                 FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
-                FieldDescription("/out/out2", DataType.DT_INT32, None)
+                FieldDescription("/out/out2", DataType.DT_INT32, Some(Seq.empty))
               )
             ),
             SignatureDescription(
               "sig2",
               inputs = List(
-                FieldDescription("/in2", DataType.DT_INT32, None)
+                FieldDescription("/in2", DataType.DT_INT32, Some(Seq.empty))
               ),
               outputs = List(
                 FieldDescription("/out2", DataType.DT_INT32, Some(List(3)))
@@ -292,7 +292,7 @@ class ContractOpsSpecs extends WordSpec {
         val flatSignature = SignatureDescription(
           "sig1",
           inputs = List(
-            FieldDescription("/in1", DataType.DT_STRING, None)
+            FieldDescription("/in1", DataType.DT_STRING, Some(Seq.empty))
           ),
           outputs = List(
             FieldDescription("/out1", DataType.DT_DOUBLE, Some(List(-1)))
@@ -329,12 +329,12 @@ class ContractOpsSpecs extends WordSpec {
         val signatureDescription = SignatureDescription(
           "sig1",
           inputs = List(
-            FieldDescription("/in/in1", DataType.DT_STRING, None),
-            FieldDescription("/in/in2", DataType.DT_INT32, None)
+            FieldDescription("/in/in1", DataType.DT_STRING, Some(Seq.empty)),
+            FieldDescription("/in/in2", DataType.DT_INT32, Some(Seq.empty))
           ),
           outputs = List(
             FieldDescription("/out/out1", DataType.DT_DOUBLE, Some(List(-1))),
-            FieldDescription("/out/out2", DataType.DT_INT32, None)
+            FieldDescription("/out/out2", DataType.DT_INT32, Some(Seq.empty))
           )
         )
 

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/SignatureCheckerSpecs.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/SignatureCheckerSpecs.scala
@@ -1,0 +1,237 @@
+package io.hydrosphere.serving.manager.model.api
+
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.contract.utils.ContractBuilders
+import io.hydrosphere.serving.manager.model.api.ops.ModelSignatureOps
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.types.DataType
+import org.scalatest.WordSpec
+
+class SignatureCheckerSpecs extends WordSpec {
+  "SignatureChecker" should {
+    "accept connection" when {
+      "two identical signatures (String,String -> String,String)" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_STRING, TensorShape.scalar)
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_STRING, TensorShape.scalar)
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isDefined)
+      }
+
+      "two identical signatures (Double[5],Double[5] -> Double[5],Double[5])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.vector(5))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(5))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(5))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.vector(5))
+
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isDefined)
+      }
+
+      "two compatible signatures (Int32[3] -> Int32[-1])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_INT32, TensorShape.vector(3))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, TensorShape.vector(3))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, TensorShape.vector(-1))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(-1))
+
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isDefined)
+      }
+
+      "two identical signatures (Double[5, 2] -> Double[5, 2])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isDefined)
+      }
+
+      "two compatible signatures (Double[5, 2] -> Double[5, -1])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.mat(5, 2))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.mat(5, -1))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.mat(5, -1))
+
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isDefined)
+      }
+
+    }
+
+    "decline connection" when {
+      "two completely different signatures (String -> Int32)" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_STRING, TensorShape.scalar)
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.scalar)
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isEmpty)
+      }
+
+      "two completely different signatures (String[3] -> String[4])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.vector(3))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_STRING, TensorShape.vector(3))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_INT32, TensorShape.vector(4))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_INT32, TensorShape.vector(4))
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isEmpty)
+      }
+
+      "two completely different signatures (Double[4] -> Double[3])" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(3))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.vector(3))
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isEmpty)
+      }
+
+      "two signatures when receiver has empty input signature" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          )
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.vector(4))
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isEmpty)
+      }
+
+      "two signatures when emitter has empty output signature" in {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          ),
+          List()
+        )
+        val sig2 = ModelSignature(
+          "sig2",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_DOUBLE, TensorShape.vector(4))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out2", DataType.DT_DOUBLE, TensorShape.vector(4))
+          )
+        )
+        assert(ModelSignatureOps.append(sig1, sig2).isEmpty)
+      }
+    }
+  }
+}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGeneratorSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGeneratorSpec.scala
@@ -28,7 +28,7 @@ class TensorExampleGeneratorSpec extends GenericUnitTest {
           "in1" -> TypedTensorFactory.create(
             TensorProto(
               dtype = DataType.DT_STRING,
-              tensorShape = None,
+              tensorShape = TensorShape.scalar.toProto,
               stringVal = List(fooString)
             )
           )
@@ -77,7 +77,7 @@ class TensorExampleGeneratorSpec extends GenericUnitTest {
           List(
             ContractBuilders.complexField(
               "in1",
-              None,
+              TensorShape.scalar.toProto,
               Seq(
                 ContractBuilders.simpleTensorModelField("a", DataType.DT_STRING, TensorShape.scalar),
                 ContractBuilders.simpleTensorModelField("b", DataType.DT_STRING, TensorShape.scalar)
@@ -94,12 +94,12 @@ class TensorExampleGeneratorSpec extends GenericUnitTest {
             TypedTensorFactory.create(
               TensorProto(
                 dtype = DataType.DT_MAP,
-                tensorShape = None,
+                tensorShape = TensorShape.scalar.toProto,
                 mapVal = Seq(
                   MapTensorData(
                     Map(
-                      "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
-                      "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                      "a" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString)),
+                      "b" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString))
                     )
                   )
                 )
@@ -137,20 +137,20 @@ class TensorExampleGeneratorSpec extends GenericUnitTest {
               mapVal = Seq(
                 MapTensorData(
                   Map(
-                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
-                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                    "a" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString))
                   )
                 ),
                 MapTensorData(
                   Map(
-                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
-                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                    "a" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString))
                   )
                 ),
                 MapTensorData(
                   Map(
-                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
-                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                    "a" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, TensorShape.scalar.toProto, stringVal = List(fooString))
                   )
                 )
               )

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGeneratorSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorExampleGeneratorSpec.scala
@@ -1,0 +1,166 @@
+package io.hydrosphere.serving.manager.model.api
+
+import com.google.protobuf.ByteString
+import io.hydrosphere.serving.contract.model_signature.ModelSignature
+import io.hydrosphere.serving.contract.utils.ContractBuilders
+import io.hydrosphere.serving.manager.GenericUnitTest
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.tensor.{MapTensorData, TensorProto, TypedTensorFactory}
+import io.hydrosphere.serving.tensorflow.types.DataType
+
+class TensorExampleGeneratorSpec extends GenericUnitTest {
+  val fooString = ByteString.copyFromUtf8("foo")
+
+  describe("TensorExampleGenerator") {
+    describe("should generate correct example") {
+      it("when scalar flat signature") {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.scalar)
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+
+        val expected = Map(
+          "in1" -> TypedTensorFactory.create(
+            TensorProto(
+              dtype = DataType.DT_STRING,
+              tensorShape = None,
+              stringVal = List(fooString)
+            )
+          )
+        )
+
+        val generated = TensorExampleGenerator(sig1).inputs
+        assert(generated === expected)
+      }
+
+      it("when vector flat signature") {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.simpleTensorModelField("in1", DataType.DT_STRING, TensorShape.vector(-1)),
+            ContractBuilders.simpleTensorModelField("in2", DataType.DT_INT32, TensorShape.vector(3))
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+
+        val expected = Map(
+          "in1" -> TypedTensorFactory.create(
+            TensorProto(
+              dtype = DataType.DT_STRING,
+              tensorShape = TensorShape.vector(-1).toProto,
+              stringVal = List(fooString)
+            )
+          ),
+          "in2" -> TypedTensorFactory.create(
+            TensorProto(
+              dtype = DataType.DT_INT32,
+              tensorShape = TensorShape.vector(3).toProto,
+              intVal = List(1, 1, 1)
+            )
+          )
+        )
+
+        val generated = TensorExampleGenerator(sig1).inputs
+        assert(generated === expected)
+      }
+
+      it("when nested singular signature") {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.complexField(
+              "in1",
+              None,
+              Seq(
+                ContractBuilders.simpleTensorModelField("a", DataType.DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("b", DataType.DT_STRING, TensorShape.scalar)
+              )
+            )
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+
+        val expected = Map(
+          "in1" ->
+            TypedTensorFactory.create(
+              TensorProto(
+                dtype = DataType.DT_MAP,
+                tensorShape = None,
+                mapVal = Seq(
+                  MapTensorData(
+                    Map(
+                      "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
+                      "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                    )
+                  )
+                )
+              )
+            )
+        )
+
+        val generated = TensorExampleGenerator(sig1).inputs
+        assert(generated === expected)
+      }
+
+      it("when nested vector signature") {
+        val sig1 = ModelSignature(
+          "sig1",
+          List(
+            ContractBuilders.complexField(
+              "in1",
+              TensorShape.vector(3).toProto,
+              Seq(
+                ContractBuilders.simpleTensorModelField("a", DataType.DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("b", DataType.DT_STRING, TensorShape.scalar)
+              )
+            )
+          ),
+          List(
+            ContractBuilders.simpleTensorModelField("out1", DataType.DT_DOUBLE, TensorShape.vector(-1))
+          )
+        )
+
+        val expected = Map(
+          "in1" -> TypedTensorFactory.create(
+            TensorProto(
+              dtype = DataType.DT_MAP,
+              tensorShape = TensorShape.vector(3).toProto,
+              mapVal = Seq(
+                MapTensorData(
+                  Map(
+                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                  )
+                ),
+                MapTensorData(
+                  Map(
+                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                  )
+                ),
+                MapTensorData(
+                  Map(
+                    "a" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString)),
+                    "b" -> TensorProto(DataType.DT_STRING, None, stringVal = List(fooString))
+                  )
+                )
+              )
+            )
+          )
+        )
+
+        val generated = TensorExampleGenerator(sig1).inputs
+        assert(generated === expected)
+      }
+    }
+  }
+}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorJson.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorJson.scala
@@ -8,7 +8,7 @@ import spray.json.{JsArray, JsNumber, JsObject, JsString}
 
 class TensorJson extends WordSpec{
   "Tensors should convert to JSON" when {
-    "classical TensorProto" in {
+    "TensorProto matrix" in {
       val stensor = StringTensor(TensorShape.mat(2, 2), Seq("never", "gonna", "give", "you"))
 
       val expected = JsArray(
@@ -19,13 +19,19 @@ class TensorJson extends WordSpec{
       assert(TensorJsonLens.toJson(stensor) === expected)
     }
 
-    "TensorProto with [-1]" in {
+    "TensorProto vector [-1]" in {
       val stensor = StringTensor(TensorShape.vector(-1) , Seq("never", "gonna", "give", "you"))
 
       val expected = JsArray(
         JsString("never"), JsString("gonna"),JsString("give"), JsString("you")
       )
 
+      assert(TensorJsonLens.toJson(stensor) === expected)
+    }
+
+    "TensorProto scalar" in {
+      val stensor = StringTensor(TensorShape.scalar , Seq("never"))
+      val expected = JsString("never")
       assert(TensorJsonLens.toJson(stensor) === expected)
     }
 

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorJson.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/TensorJson.scala
@@ -1,17 +1,15 @@
 package io.hydrosphere.serving.manager.model.api
 
-import com.google.protobuf.ByteString
 import io.hydrosphere.serving.manager.model.api.json.TensorJsonLens
 import io.hydrosphere.serving.tensorflow.TensorShape
-import io.hydrosphere.serving.tensorflow.tensor.{Int32Tensor, MapTensor, StringTensor, TensorProto}
-import io.hydrosphere.serving.tensorflow.types.DataType
+import io.hydrosphere.serving.tensorflow.tensor.{Int32Tensor, MapTensor, StringTensor}
 import org.scalatest.WordSpec
 import spray.json.{JsArray, JsNumber, JsObject, JsString}
 
 class TensorJson extends WordSpec{
   "Tensors should convert to JSON" when {
     "classical TensorProto" in {
-      val stensor = StringTensor(TensorShape(Some(List(2, 2))), Seq("never", "gonna", "give", "you"))
+      val stensor = StringTensor(TensorShape.mat(2, 2), Seq("never", "gonna", "give", "you"))
 
       val expected = JsArray(
         JsArray(JsString("never"), JsString("gonna")),

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ValidationSpecs.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/model/api/ValidationSpecs.scala
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
 import io.hydrosphere.serving.contract.utils.ContractBuilders
 import io.hydrosphere.serving.manager.model.api.tensor_builder.SignatureBuilder
+import io.hydrosphere.serving.tensorflow.TensorShape
 import io.hydrosphere.serving.tensorflow.types.DataType.{DT_BOOL, DT_FLOAT, DT_INT16, DT_STRING}
 import org.scalatest.WordSpec
 import spray.json._
@@ -26,10 +27,10 @@ class ValidationSpecs extends WordSpec {
         val signature = ModelSignature(
           signatureName = "test",
           inputs = Seq(
-            ContractBuilders.simpleTensorModelField("name", DT_STRING, None),
-            ContractBuilders.simpleTensorModelField("age", DT_INT16, None),
-            ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, None),
-            ContractBuilders.simpleTensorModelField("features", DT_FLOAT, Some(Seq(4L)))
+            ContractBuilders.simpleTensorModelField("name", DT_STRING, TensorShape.scalar),
+            ContractBuilders.simpleTensorModelField("age", DT_INT16, TensorShape.scalar),
+            ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, TensorShape.scalar),
+            ContractBuilders.simpleTensorModelField("features", DT_FLOAT, TensorShape.vector(4))
           )
         )
 
@@ -59,15 +60,15 @@ class ValidationSpecs extends WordSpec {
         val signature = ModelSignature(
           signatureName = "test",
           inputs = Seq(
-            ContractBuilders.simpleTensorModelField("isOk", DT_BOOL, None),
+            ContractBuilders.simpleTensorModelField("isOk", DT_BOOL, TensorShape.scalar),
             ContractBuilders.complexField(
               "person",
               None,
               Seq(
-                ContractBuilders.simpleTensorModelField("name", DT_STRING, None),
-                ContractBuilders.simpleTensorModelField("age", DT_INT16, None),
-                ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, None),
-                ContractBuilders.simpleTensorModelField("features", DT_FLOAT, Some(Seq(4L)))
+                ContractBuilders.simpleTensorModelField("name", DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("age", DT_INT16, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("features", DT_FLOAT, TensorShape.scalar)
               )
             )
           )
@@ -100,8 +101,8 @@ class ValidationSpecs extends WordSpec {
         val signature = ModelSignature(
           signatureName = "test",
           inputs = Seq(
-            ContractBuilders.simpleTensorModelField("name", DT_STRING, None),
-            ContractBuilders.simpleTensorModelField("birthday", DT_STRING, None)
+            ContractBuilders.simpleTensorModelField("name", DT_STRING, TensorShape.scalar),
+            ContractBuilders.simpleTensorModelField("birthday", DT_STRING, TensorShape.scalar)
           )
         )
 
@@ -109,7 +110,7 @@ class ValidationSpecs extends WordSpec {
         val result = validator.convert(input)
 
         assert(result.isLeft, result)
-        assert(result.left.get.getMessage.contains("Couldn't find 'birthday' field"))
+        assert(result.left.get.message.contains("Couldn't find 'birthday' field"))
       }
 
       "nested json is incompatible with contract" in {
@@ -129,15 +130,15 @@ class ValidationSpecs extends WordSpec {
         val signature = ModelSignature(
           signatureName = "test",
           inputs = Seq(
-            ContractBuilders.simpleTensorModelField("isOk", DT_BOOL, None),
+            ContractBuilders.simpleTensorModelField("isOk", DT_BOOL, TensorShape.scalar),
             ContractBuilders.complexField(
               "person",
               None,
               Seq(
-                ContractBuilders.simpleTensorModelField("surname", DT_STRING, None),
-                ContractBuilders.simpleTensorModelField("age", DT_INT16, None),
-                ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, None),
-                ContractBuilders.simpleTensorModelField("features", DT_FLOAT, Some(Seq(4L)))
+                ContractBuilders.simpleTensorModelField("surname", DT_STRING, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("age", DT_INT16, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("isEmployed", DT_BOOL, TensorShape.scalar),
+                ContractBuilders.simpleTensorModelField("features", DT_FLOAT, TensorShape.vector(4))
               )
             )
           )
@@ -147,7 +148,7 @@ class ValidationSpecs extends WordSpec {
         val result = validator.convert(input)
 
         assert(result.isLeft, result)
-        val errorMsg = result.left.get.getMessage
+        val errorMsg = result.left.get.message
         assert(errorMsg contains "Errors while validating subfields for 'person' field")
         assert(errorMsg contains "Couldn't find 'surname' field")
       }

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/service/ModelBuildServiceSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/service/ModelBuildServiceSpec.scala
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 import cats.instances.all._
 import io.hydrosphere.serving.contract.model_contract.ModelContract
-import io.hydrosphere.serving.contract.utils.ops.ModelContractOps._
+import io.hydrosphere.serving.manager.model.api.ops.ModelContractOps._
 import io.hydrosphere.serving.manager.GenericUnitTest
 import io.hydrosphere.serving.manager.controller.model.ModelUpload
 import io.hydrosphere.serving.manager.model.{ModelBuildStatus, Result}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/service/storage/FetcherSpecs.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/service/storage/FetcherSpecs.scala
@@ -63,10 +63,10 @@ class FetcherSpecs extends GenericUnitTest {
         Seq(ModelSignature(
           "infer",
           Seq(
-            ContractBuilders.simpleTensorModelField("Input73", DataType.DT_FLOAT, Some(Seq(1, 1, 28, 28)))
+            ContractBuilders.simpleTensorModelField("Input73", DataType.DT_FLOAT, TensorShape.mat(1, 1, 28, 28))
           ),
           Seq(
-            ContractBuilders.simpleTensorModelField("Plus422_Output_0", DataType.DT_FLOAT, Some(Seq(1, 10)))
+            ContractBuilders.simpleTensorModelField("Plus422_Output_0", DataType.DT_FLOAT, TensorShape.mat(1, 10))
           ))
         )
       )

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/util/TensorUtilSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/util/TensorUtilSpec.scala
@@ -1,0 +1,55 @@
+package io.hydrosphere.serving.manager.util
+
+import io.hydrosphere.serving.manager.GenericUnitTest
+import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.tensor.DoubleTensor
+
+class TensorUtilSpec extends GenericUnitTest {
+  describe("TensorUtilSpec") {
+    // test cases
+
+    // [-1, 2, 3]
+
+    // a b c d e f g h k l - 10
+    // 1. 10 % 3 != 0
+    // 2. Fail
+
+    // a b c d e f g h k - 9
+    // 1. 9 % 3 == 0; 9 / 3 == 3
+    // 2. 3 % 2 != 0
+    // 3. Fail
+
+    // a b c d e f g - 6
+    // 1. 6 % 3 == 0; 6 / 3 == 2
+    // 2. 2 % 2 == 0; 2 / 2 == 1
+    // 3. 1 % x == 0
+    // 4. ok
+
+    // a b c d e f g h k l q w - 12
+    // 1. 12 % 3 == 0; 12 / 3 == 4
+    // 2. 4 % 2 == 0; 4 / 2 == 2
+    // 3. 2 % x == 0
+    // 4. ok
+    it("should leave correct and static shape as-is") {
+      val tensor = DoubleTensor(TensorShape.mat(2, 2, 3), Seq(1,2,3,4,5,6,7,8,9,10,11,12))
+      val shapeRes = TensorUtil.verifyShape(tensor)
+      assert(shapeRes.isRight, shapeRes)
+      val shaped = shapeRes.right.get
+      assert(shaped.shape.dims === Some(Seq(2, 2, 3)))
+    }
+
+    it("should fill dynamic dims and return it for correct shape") {
+      val tensor = DoubleTensor(TensorShape.mat(-1, 3, 2), Seq(1,2,3,4,5,6))
+      val shapeRes = TensorUtil.verifyShape(tensor)
+      assert(shapeRes.isRight, shapeRes)
+      val shaped = shapeRes.right.get
+      assert(shaped.shape.dims === Some(Seq(1, 3, 2)))
+    }
+
+    it("should fail on incorrect shape") {
+      val tensor = DoubleTensor(TensorShape.mat(-1, 3, 3), Seq(1,2,3,4,5,6,7,8,9,10))
+      val shapeRes = TensorUtil.verifyShape(tensor)
+      assert(shapeRes.isLeft, shapeRes)
+    }
+  }
+}

--- a/manager/src/test/scala/io/hydrosphere/serving/manager/util/TensorUtilSpec.scala
+++ b/manager/src/test/scala/io/hydrosphere/serving/manager/util/TensorUtilSpec.scala
@@ -2,6 +2,7 @@ package io.hydrosphere.serving.manager.util
 
 import io.hydrosphere.serving.manager.GenericUnitTest
 import io.hydrosphere.serving.tensorflow.TensorShape
+import io.hydrosphere.serving.tensorflow.TensorShape.Dims
 import io.hydrosphere.serving.tensorflow.tensor.DoubleTensor
 
 class TensorUtilSpec extends GenericUnitTest {
@@ -35,7 +36,7 @@ class TensorUtilSpec extends GenericUnitTest {
       val shapeRes = TensorUtil.verifyShape(tensor)
       assert(shapeRes.isRight, shapeRes)
       val shaped = shapeRes.right.get
-      assert(shaped.shape.dims === Some(Seq(2, 2, 3)))
+      assert(shaped.shape === Dims(Seq(2, 2, 3)))
     }
 
     it("should fill dynamic dims and return it for correct shape") {
@@ -43,7 +44,7 @@ class TensorUtilSpec extends GenericUnitTest {
       val shapeRes = TensorUtil.verifyShape(tensor)
       assert(shapeRes.isRight, shapeRes)
       val shaped = shapeRes.right.get
-      assert(shaped.shape.dims === Some(Seq(1, 3, 2)))
+      assert(shaped.shape === Dims(Seq(1, 3, 2)))
     }
 
     it("should fail on incorrect shape") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val scalaTestVersion = "3.0.3"
   val slickPgVersion = "0.15.4"
   val awsSdkVersion = "1.11.312"
-  val servingGrpcScala = "0.1.12"
+  val servingGrpcScala = "0.1.13"
   val catsV = "1.1.0"
   val elastic4sVersion = "6.2.4"
   val envoyDataPlaneApi = "v1.6.0_1"
@@ -46,9 +46,9 @@ object Dependencies {
   )
 
   lazy val grpcDependencies = Seq(
-    "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion exclude("com.google.api.grpc", "proto-google-common-protos"),
+    "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion exclude("com.google.api.grpc", "proto-google-common-protos"),
     "io.hydrosphere" %% "serving-grpc-scala" % servingGrpcScala exclude("com.google.api.grpc", "proto-google-common-protos"),
-    "io.grpc" % "grpc-netty" % com.trueaccord.scalapb.compiler.Version.grpcJavaVersion exclude("com.google.api.grpc", "proto-google-common-protos"),
+    "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion exclude("com.google.api.grpc", "proto-google-common-protos"),
     "io.hydrosphere" %% "envoy-data-plane-api" % envoyDataPlaneApi exclude("com.google.api.grpc", "proto-google-common-protos")
   )
 


### PR DESCRIPTION
1. Move manager code from library
2. Fix negative shape inference (now manager calculates and checks actual shape)
3. Fix shape inference for `None`, `[]`, and `[None, N]` shapes