### PR TITLE
XDS Aggregation stream - empty DiscoveryResponse on every DiscoverRequest

### DIFF
--- a/manager/src/main/resources/log4j2.xml
+++ b/manager/src/main/resources/log4j2.xml
@@ -17,7 +17,7 @@
         <Logger name="slick" level="INFO" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Logger name="io.hydrosphere.serving" level="DEBUG" additivity="false">
+        <Logger name="io.hydrosphere.serving" level="INFO" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>

--- a/manager/src/main/resources/log4j2.xml
+++ b/manager/src/main/resources/log4j2.xml
@@ -17,7 +17,7 @@
         <Logger name="slick" level="INFO" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
-        <Logger name="io.hydrosphere.serving" level="INFO" additivity="false">
+        <Logger name="io.hydrosphere.serving" level="DEBUG" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/AbstractDSActor.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/AbstractDSActor.scala
@@ -81,11 +81,17 @@ abstract class AbstractDSActor[A <: GeneratedMessage with Message[A]](val typeUr
         observerResources.put(subscribe.responseObserver, subscribe.discoveryRequest.resourceNames.toSet)
       }
       val differentVersion = {
-        !subscribe.discoveryRequest.versionInfo.contains(version.toString)
+        version.toString != subscribe.discoveryRequest.versionInfo
       }
 
       if (differentVersion || needUpdateResource) {
         sendToObserver(subscribe.responseObserver)
+      } else {
+        send(DiscoveryResponse(
+          typeUrl = "type.googleapis.com/io.hydrosphere.serving.Empty",
+          versionInfo = version.toString,
+          nonce = sentRequest.get().toString
+        ), subscribe.responseObserver)
       }
 
     case unsubcribe: UnsubscribeMsg =>

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/AbstractDSActor.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/AbstractDSActor.scala
@@ -88,7 +88,7 @@ abstract class AbstractDSActor[A <: GeneratedMessage with Message[A]](val typeUr
         sendToObserver(subscribe.responseObserver)
       } else {
         send(DiscoveryResponse(
-          typeUrl = "type.googleapis.com/io.hydrosphere.serving.Empty",
+          typeUrl = "type.googleapis.com/com.google.protobuf.Empty",
           versionInfo = version.toString,
           nonce = sentRequest.get().toString
         ), subscribe.responseObserver)

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/RouteDSActor.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/RouteDSActor.scala
@@ -3,7 +3,7 @@ package io.hydrosphere.serving.manager.service.envoy.xds
 import envoy.api.v2.core.{HeaderValue, HeaderValueOption}
 import envoy.api.v2.{DiscoveryResponse, RouteConfiguration}
 import envoy.api.v2.route.RouteAction.ClusterSpecifier
-import envoy.api.v2.route._
+import envoy.api.v2.route.{Route, _}
 import io.grpc.stub.StreamObserver
 import io.hydrosphere.serving.grpc.Headers
 import io.hydrosphere.serving.manager.model.db.Application
@@ -139,6 +139,18 @@ class RouteDSActor extends AbstractDSActor[RouteConfiguration](typeUrl = "type.g
         ),
         Route(
           `match` = Some(RouteMatch(
+            pathSpecifier = RouteMatch.PathSpecifier.Prefix("/gateway"),
+            headers = Seq(HeaderMatcher(
+              name = "content-type",
+              value = "application/grpc"
+            ))
+          )),
+          action = Route.Action.Route(RouteAction(
+            clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.GATEWAY_NAME)
+          ))
+        ),
+        Route(
+          `match` = Some(RouteMatch(
             pathSpecifier = RouteMatch.PathSpecifier.Path("/health")
           )),
           action = Route.Action.Route(RouteAction(
@@ -191,6 +203,14 @@ class RouteDSActor extends AbstractDSActor[RouteConfiguration](typeUrl = "type.g
           )),
           action = Route.Action.Route(RouteAction(
             clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.PROFILER_HTTP_NAME)
+          ))
+        ),
+        Route(
+          `match` = Some(RouteMatch(
+            pathSpecifier = RouteMatch.PathSpecifier.Prefix("/gateway")
+          )),
+          action = Route.Action.Route(RouteAction(
+            clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.GATEWAY_HTTP_NAME)
           ))
         ),
         Route(

--- a/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/RouteDSActor.scala
+++ b/manager/src/main/scala/io/hydrosphere/serving/manager/service/envoy/xds/RouteDSActor.scala
@@ -127,6 +127,18 @@ class RouteDSActor extends AbstractDSActor[RouteConfiguration](typeUrl = "type.g
       routes = Seq(
         Route(
           `match` = Some(RouteMatch(
+            pathSpecifier = RouteMatch.PathSpecifier.Prefix("/tensorflow.serving.PredictionService"),
+            headers = Seq(HeaderMatcher(
+              name = "content-type",
+              value = "application/grpc"
+            ))
+          )),
+          action = Route.Action.Route(RouteAction(
+            clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.GATEWAY_NAME)
+          ))
+        ),
+        Route(
+          `match` = Some(RouteMatch(
             pathSpecifier = RouteMatch.PathSpecifier.Prefix("/"),
             headers = Seq(HeaderMatcher(
               name = "content-type",
@@ -135,18 +147,6 @@ class RouteDSActor extends AbstractDSActor[RouteConfiguration](typeUrl = "type.g
           )),
           action = Route.Action.Route(RouteAction(
             clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.MANAGER_NAME)
-          ))
-        ),
-        Route(
-          `match` = Some(RouteMatch(
-            pathSpecifier = RouteMatch.PathSpecifier.Prefix("/gateway"),
-            headers = Seq(HeaderMatcher(
-              name = "content-type",
-              value = "application/grpc"
-            ))
-          )),
-          action = Route.Action.Route(RouteAction(
-            clusterSpecifier = ClusterSpecifier.Cluster(CloudDriverService.GATEWAY_NAME)
           ))
         ),
         Route(


### PR DESCRIPTION
Since manager <-> gateway stream seems okay on application level, and there is no way to ensure if stream is actually alright, I implemented an empty `DiscoveryResponse` heartbeat message response for every `DiscoveryRequest`.

This allows stream clients to implement app-level heartbeats.