### PR TITLE
Open gRPC port in an example docker-compose.yaml 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,7 @@ services:
        - gateway
      ports:
        - "80:80"
+       - "9090:9090"
      networks:
        - extnet
        - hydronet


### PR DESCRIPTION
I've opened added a `9090:9090` port forwarding to our `docker-compose.yaml`, so we could use `predictors` from a `hydrosdk` and connect to a gRPC channel through `hydrosdk.Cluster` 

e.g. `cluster = Cluster("http://localhost", grpc_address="localhost:9090")` was failing previously
