### PR TITLE
add insecure registry options

### DIFF
--- a/helm/docker-registry/templates/_helpers.tpl
+++ b/helm/docker-registry/templates/_helpers.tpl
@@ -41,3 +41,7 @@ Create chart name and version as used by the chart label.
 {{- define "docker-registry.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "docker-registry-proxy.fullname" -}}
+{{- printf "%s-%s" .Release.Name "docker-registry-proxy" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/docker-registry/templates/deployment.yaml
+++ b/helm/docker-registry/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     matchLabels:
       app: {{ template "docker-registry.fullname" . }}
       release: {{ .Release.Name }}
+      logging: "true"
   template:
     metadata:
       labels:
@@ -22,7 +23,6 @@ spec:
         release: {{ .Release.Name }}
         logging: "true"
     spec:
-      {{- if not .Values.global.registry.insecure }}
       initContainers:
         - name: "htpasswd-{{ .Chart.Name }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -41,7 +41,6 @@ spec:
               subPath: entrypoint.sh
             - name: "auth-{{ .Chart.Name }}"
               mountPath: /auth
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -51,7 +50,6 @@ spec:
               containerPort: 5000
               protocol: TCP
           env:
-            {{- if not .Values.global.registry.insecure }}
             - name: REGISTRY_AUTH
               value: "htpasswd"
             - name: REGISTRY_AUTH_HTPASSWD_REALM
@@ -60,7 +58,6 @@ spec:
               value: "/auth/htpasswd"
             - name: REGISTRY_HTTP_SECRET
               value: "{{ .Values.global.registry.password }}" 
-            {{- end }}
             {{- if and .Values.global.persistence.mode (eq .Values.global.persistence.mode "s3") }}
             - name: REGISTRY_HEALTH_STORAGEDRIVER_ENABLED
               value: "false"            
@@ -77,12 +74,10 @@ spec:
             - name: REGISTRY_STORAGE_S3_ROOTDIRECTORY
               value: /{{ .Release.Name }}/
             {{- end }}
-          {{- if not .Values.global.registry.insecure }}
           volumeMounts:
             - name: "auth-{{ .Chart.Name }}"
               mountPath: /auth
               readOnly: true
-          {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -110,8 +105,6 @@ spec:
           configMap:
             defaultMode: 0700
             name: {{ include "docker-registry.fullname" . }}
-        {{- if not .Values.global.registry.insecure }}
         - name: "auth-{{ .Chart.Name }}"
           emptyDir: {}
-        {{- end }}
 {{- end -}}

--- a/helm/docker-registry/templates/ingress.yaml
+++ b/helm/docker-registry/templates/ingress.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.global.registry.internal -}}
+{{- if and .Values.global.ingress.enabled .Values.global.registry.internal }}
 apiVersion: {{ include "docker-registry.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    {{- if not .Values.global.registry.insecure }}
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.issuer | quote }}
-    {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "1800"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
@@ -23,10 +21,8 @@ spec:
           serviceName: {{ template "docker-registry.fullname" . }}
           servicePort: 5000
         path: /
-  {{- if not .Values.global.registry.insecure }}
   tls:
   - hosts:
     - {{ .Values.global.registry.url }}
     secretName: {{ .Release.Name }}-registry-tls
-  {{- end }}
 {{- end -}}

--- a/helm/docker-registry/templates/registry-proxy.yaml
+++ b/helm/docker-registry/templates/registry-proxy.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.global.registry.internal (ne .Values.global.ingress.enabled true) }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ template "docker-registry-proxy.fullname" . }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: "{{ template "docker-registry-proxy.fullname" . }}"
+    kubernetes.io/cluster-service: "true"
+    version: v0.4
+    app: "{{ template "docker-registry-proxy.fullname" . }}"
+    chart: {{ include "docker-registry.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+        k8s-app: "{{ template "docker-registry-proxy.fullname" . }}"
+        kubernetes.io/name: "{{ template "docker-registry-proxy.fullname" . }}"
+        kubernetes.io/cluster-service: "true"
+        version: v0.4
+  template:
+    metadata:
+      labels:
+        k8s-app: "{{ template "docker-registry-proxy.fullname" . }}"
+        kubernetes.io/name: "{{ template "docker-registry-proxy.fullname" . }}"
+        kubernetes.io/cluster-service: "true"
+        version: v0.4
+    spec:
+      containers:
+      - name: "{{ template "docker-registry-proxy.fullname" . }}"
+        image: gcr.io/google_containers/kube-registry-proxy:0.4
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        env:
+        - name: REGISTRY_HOST
+          value: "{{ template "docker-registry.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local"
+        - name: REGISTRY_PORT
+          value: "5000"
+        ports:
+        - name: registry
+          containerPort: 80
+          hostPort: 5000
+
+{{- end -}}

--- a/helm/docker-registry/values.yaml
+++ b/helm/docker-registry/values.yaml
@@ -4,13 +4,14 @@
 
 global:
   registry:
-    internal: false #Use internal registry or external (for internal - ingress required)
-    insecure: false #Use insecure docker registry
+    internal: true #Use internal registry or external (for internal - ingress required)
+    insecure: true #Use insecure docker registry
     url: index.docker.io #Domain name to internal\external registry
     username: example #Internal\external registry username
     password: example #Internal\external registry password
 
   ingress:
+    enabled: false
     issuer: letsencrypt-prod #Cert-manager issuer name
 
   persistence:

--- a/helm/manager/templates/_helpers.tpl
+++ b/helm/manager/templates/_helpers.tpl
@@ -35,7 +35,15 @@ Create chart name and version as used by the chart label.
 Create dockerconfig.json contents
 */}}
 {{- define "manager.dockerconfig" -}}
+{{- if .Values.global.registry.internal -}}
+{{- if .Values.global.ingress.enabled -}}
 {{- printf "{\"auths\": {\"%s\": {\"username\": \"%s\", \"password\": \"%s\", \"auth\": \"%s\"}}}" .Values.global.registry.url .Values.global.registry.username .Values.global.registry.password (printf "%s:%s" .Values.global.registry.username .Values.global.registry.password | b64enc) | b64enc }}
+{{- else -}}
+{{- printf "{\"auths\": {\"%s\": {\"username\": \"%s\", \"password\": \"%s\", \"auth\": \"%s\"}, \"localhost:5000\": {\"username\": \"%s\", \"password\": \"%s\", \"auth\": \"%s\"}}}" (printf "%s-docker-registry.%s.svc.cluster.local:5000" .Release.Name .Release.Namespace) .Values.global.registry.username .Values.global.registry.password (printf "%s:%s" .Values.global.registry.username .Values.global.registry.password | b64enc) .Values.global.registry.username .Values.global.registry.password (printf "%s:%s" .Values.global.registry.username .Values.global.registry.password | b64enc) | b64enc }}
+{{- end -}}
+{{- else -}}
+{{- printf "{\"auths\": {\"%s\": {\"username\": \"%s\", \"password\": \"%s\", \"auth\": \"%s\"}}}" .Values.global.registry.url .Values.global.registry.username .Values.global.registry.password (printf "%s:%s" .Values.global.registry.username .Values.global.registry.password | b64enc) | b64enc }}
+{{- end -}}
 {{- end -}}
 
 {{- define "postgresql.fullname" -}}
@@ -48,4 +56,8 @@ Create dockerconfig.json contents
 
 {{- define "docker-registry.fullname" -}}
 {{- printf "%s-%s" .Release.Name "docker-registry" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "docker-registry-proxy.fullname" -}}
+{{- printf "%s-%s" .Release.Name "docker-registry-proxy" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/manager/templates/deployment.yaml
+++ b/helm/manager/templates/deployment.yaml
@@ -28,7 +28,12 @@ spec:
           image: docker:18.06.0-ce-dind
           securityContext:
             privileged: true
-          {{- if .Values.global.registry.insecure }}
+          {{- if .Values.global.registry.internal }}
+            {{- if and (ne .Values.global.ingress.enabled true) .Values.global.registry.insecure }}
+          args: [{{ printf "--insecure-registry=%s" (printf "%s-docker-registry.%s.svc.cluster.local:5000" .Release.Name .Release.Namespace) }}]
+             {{- end }}
+          {{- end }} 
+          {{- if and (ne .Values.global.registry.internal true) .Values.global.registry.insecure }}
           args: [{{ printf "--insecure-registry=%s" .Values.global.registry.url }}]
           {{- end }}
         - name: kubectl-proxy
@@ -75,14 +80,28 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.global.registry.internal }}
+              {{- if .Values.global.ingress.enabled }}
             - name: REMOTE_DOCKER_REGISTRY_HOST
-              value: "{{ .Values.global.registry.url }}" 
+              value: "{{ .Values.global.registry.url }}"
+            - name: REMOTE_DOCKER_PULL_HOST
+              value: "{{ .Values.global.registry.url }}"
+              {{- else }}  
+            - name: REMOTE_DOCKER_REGISTRY_HOST
+              value: "{{ template "docker-registry.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:5000"
+            - name: REMOTE_DOCKER_PULL_HOST
+              value: "localhost:5000"
+              {{- end }} 
+            {{- else }}
+            - name: REMOTE_DOCKER_REGISTRY_HOST
+              value: "{{ .Values.global.registry.url }}"
+            - name: REMOTE_DOCKER_PULL_HOST
+              value: "{{ .Values.global.registry.url }}"
+            {{- end }}
             - name: REMOTE_DOCKER_REGISTRY_PASSWORD
               value: "{{ .Values.global.registry.password }}"              
             - name: REMOTE_DOCKER_REGISTRY_USERNAME
               value: "{{ .Values.global.registry.username }}"
-            - name: REMOTE_DOCKER_PULL_HOST
-              value: "{{ .Values.global.registry.url }}"
             {{- with .Values.env }}
 {{ toYaml . | indent 12 }}
             {{- end }}

--- a/helm/manager/values.yaml
+++ b/helm/manager/values.yaml
@@ -8,9 +8,12 @@ serviceAccount:
   create: true
   
 global:
+  ingress:
+    enabled: false
+
   registry:
-    internal: false #Use internal registry or external (for internal - ingress required)
-    insecure: false #Use insecure docker registry
+    internal: true #Use internal registry or external (for internal - ingress required)
+    insecure: true #Use insecure docker registry
     url: index.docker.io #Domain name to internal\external registry
     username: example #Internal\external registry username
     password: example #Internal\external registry password

--- a/helm/serving/Chart.yaml
+++ b/helm/serving/Chart.yaml
@@ -1,4 +1,15 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: serving
-version: 2.0.6-SNAPSHOT
+version: 2.4.3
+icon: https://media-exp1.licdn.com/dms/image/C4D0BAQFdJwT_5sqKCQ/company-logo_200_200/0?e=1602115200&v=beta&t=AY1uflcZAvWxrdqe67dlIcRNwDViEuCeFOVt6grpFQE
+keywords:
+  - hydrosphere
+home: https://hydrosphere.io/
+source: 
+  - https://github.com/Hydrospheredata/hydro-serving
+maintainers:
+  - name: Hydrosphere.Io
+    email: support@hydrosphere.io
+    url: https://hydrosphere.io  
+

--- a/helm/serving/README.md
+++ b/helm/serving/README.md
@@ -11,45 +11,48 @@ The following table lists the configurable parameters of the Serving chart and t
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `global.shadowing_on` | Enable shadowing support | `true` |
-| `global.frontend_url` | Frontend url | `"http://hydro-serving.local"` |
-| `global.alerting_on` | Enable alert events by prometheus alert manager | `false` |
-| `global.persistence.enabled` | Enable persistence s3 bucket | `false` |
-| `global.dockerRegistry.enabled` | Enable internal docker registry. manager use it for store model image | `true` |
-| `global.dockerRegistry.host` | Dns name of docker registry | `""` |
-| `global.dockerRegistry.username` | Docker registry username | `"example"` |
-| `global.dockerRegistry.password` | Docker registry password | `"example"` |
-| `global.hydrosphere.docker.host` | Dns name of docker registry where store all service image (like a manager, ui, gateway etc) | `""` |
-| `global.hydrosphere.docker.username` | Docker registry username | `""` |
-| `global.hydrosphere.docker.password` | Docker registry password | `""` |
-| `global.mongodb.usePassword` | Use mongo with password auth | `true` |
-| `global.mongodb.mongodbRootPassword` | Superuser password | `"hydr0s3rving"` |
-| `global.mongodb.mongodbUsername` | Mongodb username | `"root"` |
-| `global.mongodb.mongodbPassword` | Mongodb password | `"hydr0s3rving"` |
-| `global.mongodb.mongodbAuthDatabase` | Mongodb authdatabase | `"admin"` |
-| `global.mongodb.mongodbDatabase` | Mongodb database | `"hydro-serving-data-profiler"` |
-| `mongodb.enabled` | Enable mongodb usage | `true` |
-| `mongodb.image.repository` | Docker repository to pull the image from | `"bitnami/mongodb"` |
-| `mongodb.image.tag` | Image tag to use | `"4.0.13-debian-9-r22"` |
-| `mongodb.image.pullPolicy` | Policy for kubernetes to use when pulling images | `"IfNotPresent"` |
-| `postgresql.enabled` |  | `true` |
-| `postgresql.image.repository` |  | `"bitnami/postgresql"` |
-| `postgresql.image.tag` |  | `9.6` |
-| `postgresql.image.pullPolicy` |  | `"IfNotPresent"` |
-| `postgresql.postgresqlUsername` |  | `"postgres"` |
-| `postgresql.postgresqlPassword` |  | `"hydr0s3rving"` |
-| `postgresql.postgresqlDatabase` |  | `"hydro-serving"` |
-| `ui.public` |  | `true` |
-| `ui.ingress.enabled` |  | `false` |
-| `ui.ingress.annotations` |  | `{}` |
-| `ui.ingress.hosts` |  | `["hydro-serving.local"]` |
-| `ui.ingress.path` |  | `"/"` |
-| `ui.ingress.tls` |  | `[]` |
-| `manager.postgres.postgresqlUsername` |  | `"postgres"` |
-| `manager.postgres.postgresqlPassword` |  | `"hydr0s3rving"` |
-| `manager.postgres.postgresqlDatabase` |  | `"hydro-serving"` |
-| `docker-registry.proxy.enabled` |  | `true` |
-| `docker-registry.ingress.enabled` |  | `false` |
+| `global.ingress.enabled` |  | `false` |
+| `global.ingress.host` | Domain name for the frontend ingress. | `"ui.example.io"` |
+| `global.ingress.path` | Path, which will match the service. | `"/"` |
+| `global.ingress.enableGrpc` | Enable grpc endpoints for services. works only with `path: "/"`. | `true` |
+| `global.ingress.issuer` | A name of the cert-manager issuer name, configured within the | `"letsencrypt-prod"` |
+| `global.registry.internal` | Internal/external mode for the registry. in case of internal registry | `true` |
+| `global.registry.insecure` | Use insecure docker registry | `true` |
+| `global.registry.url` | Domain name for internal\external registry. in case | `"index.docker.io/username"` |
+| `global.registry.username` | Internal\external registry username | `"example"` |
+| `global.registry.password` | Internal\external registry password | `"example"` |
+| `global.hydrosphere.docker.host` |  | `"harbor.hydrosphere.io/hydro-serving"` |
+| `global.hydrosphere.docker.username` |  | `"developers"` |
+| `global.hydrosphere.docker.password` | Registry password for accessing closed images | `""` |
+| `global.persistence.mode` | Persistence mode for services (one of s3, minio) | `"minio"` |
+| `global.persistence.accessKey` | Accesskeyid for s3 or minio | `"ACCESSKEYEXAMPLE"` |
+| `global.persistence.secretKey` | Secretkeyid for s3 or minio | `"SECRETKEYEXAMPLE"` |
+| `global.persistence.region` | Region of the bucket in case of s3 persistence mode. | `"eu-central-1"` |
+| `global.persistence.bucket` | S3 bucket name in case of s3 persistence mode. | `"example"` |
+| `global.mongodb.url` | Mongodb host in case of using external mongodb instance. if not specified, | `""` |
+| `global.mongodb.rootPassword` | Mongodb root password | `"hydr0s3rving"` |
+| `global.mongodb.username` | Mongodb username | `"root"` |
+| `global.mongodb.password` | Mongodb password | `"hydr0s3rving"` |
+| `global.mongodb.authDatabase` | Mongodb auth database | `"admin"` |
+| `global.mongodb.database` | Mongodb database name | `"hydro-serving-data-profiler"` |
+| `global.postgresql.url` | Postgresql host in case of using external postgresql instance. if not specified, | `""` |
+| `global.postgresql.username` | Postgresql username | `"postgres"` |
+| `global.postgresql.password` | Postgresql password | `"hydr0s3rving"` |
+| `global.postgresql.database` | Postgresql database name | `"hydro-serving"` |
+| `global.alertmanager.url` | Alertmanager address if external use (address:port). if not specified, | `""` |
+| `global.tolerations` |  | `[]` |
+| `prometheus-am.config.global.smtp_smarthost` | Smtp relay host | `"localhost:25"` |
+| `prometheus-am.config.global.smtp_auth_username` | Smtp relay username | `"mailbot"` |
+| `prometheus-am.config.global.smtp_auth_identity` | Smtp relay username identity | `"mailbot"` |
+| `prometheus-am.config.global.smtp_auth_password` | Smtp relay password | `"mailbot"` |
+| `prometheus-am.config.global.smtp_from` | Email address of the sender | `"no-reply@hydrosphere.io"` |
+| `prometheus-am.config.route.group_by` |  | `["alertname", "modelVersionId"]` |
+| `prometheus-am.config.route.group_wait` |  | `"10s"` |
+| `prometheus-am.config.route.group_interval` |  | `"10s"` |
+| `prometheus-am.config.route.repeat_interval` |  | `"1h"` |
+| `prometheus-am.config.route.receiver` |  | `"default"` |
+| `prometheus-am.config.receivers` |  | `[{"name": "default", "email_configs": [{"to": "customer@example.io"}]}]` |
+| `ui.public` |  | `false` |
 
 
 

--- a/helm/serving/values.yaml
+++ b/helm/serving/values.yaml
@@ -1,27 +1,43 @@
 global:
   ingress:
     enabled: false
-    frontendUrl: ui.example.io # Domain name for the frontend ingress.
-    path: "/"
+    host: ui.example.io # Domain name for the frontend ingress.
+    path: "/" # Path, which will match the service.
+    enableGrpc: true # Enable grpc endpoints for services. Works only with `path: "/"`. 
     issuer: letsencrypt-prod # A name of the cert-manager issuer name, configured within the 
                              # cluster.
 
   registry:
     internal: true # Internal/external mode for the registry. In case of internal registry 
                     # mode, a new registry instance will be deployed within the cluster.
-    insecure: true #Use insecure docker registry
+    insecure: true # Use insecure docker registry
     url: "index.docker.io/username" # Domain name for internal\external registry. In case 
                                     # of internal registry, a new ingress resource will be 
                                     # created.
     username: "example" # Internal\external registry username
     password: "example" # Internal\external registry password
-        
+  
+  hydrosphere:  
+    docker:
+      host: "harbor.hydrosphere.io/hydro-serving"
+      username: "developers"
+      password: "" # Registry password for accessing closed images
+      
   persistence:
-    mode: local # Persistence mode for services (one of s3, minio)
+    mode: minio # Persistence mode for services (one of s3, minio)
     accessKey: ACCESSKEYEXAMPLE # accesskeyid for s3 or minio
     secretKey: SECRETKEYEXAMPLE # secretkeyid for s3 or minio
     region: eu-central-1 # Region of the bucket in case of S3 persistence mode.  
     bucket: example # S3 bucket name in case of S3 persistence mode.
+
+  mongodb:
+    url: "" # Mongodb host in case of using external mongodb instance. If not specified, 
+            # a new instance will be deployed within the cluster.
+    rootPassword: hydr0s3rving # Mongodb root password
+    username: root # Mongodb username
+    password: hydr0s3rving # Mongodb password
+    authDatabase: admin # Mongodb auth database
+    database: hydro-serving-data-profiler # Mongodb database name
 
   postgresql:
     url: "" # Postgresql host in case of using external postgresql instance. If not specified, 
@@ -29,6 +45,38 @@ global:
     username: postgres # Postgresql username
     password: hydr0s3rving # Postgresql password
     database: hydro-serving # Postgresql database name 
-  
+
+  alertmanager:
+    url: "" #Alertmanager address if external use (address:port). If not specified, 
+            # a new instance will be deployed within the cluster.
+
+  tolerations: []
+    # - key: key
+    #   operator: Equal
+    #   value: value
+    #   effect: NoSchedule  
+
+prometheus-am:
+  config:
+    global: 
+      smtp_smarthost: localhost:25 # SMTP relay host
+      smtp_auth_username: mailbot # SMTP relay username 
+      smtp_auth_identity: mailbot # SMTP relay username identity
+      smtp_auth_password: mailbot # SMTP relay password
+      smtp_from: no-reply@hydrosphere.io # Email address of the sender
+    route:
+      group_by: [alertname, modelVersionId]
+      group_wait: 10s
+      group_interval: 10s
+      repeat_interval: 1h
+      receiver: default
+    receivers:
+    - name: default
+      email_configs: # List of email addresses to send alarms to
+      - to: customer@example.io 
+
 ui:
+  # `public: true` will deploy an open source version
+  # `public: false` will deploy a closed source version
   public: true
+

--- a/helm/serving/values.yaml
+++ b/helm/serving/values.yaml
@@ -2,26 +2,22 @@ global:
   ingress:
     enabled: false
     frontendUrl: ui.example.io # Domain name for the frontend ingress.
+    path: "/"
     issuer: letsencrypt-prod # A name of the cert-manager issuer name, configured within the 
                              # cluster.
 
   registry:
-    internal: false # Internal/external mode for the registry. In case of internal registry 
+    internal: true # Internal/external mode for the registry. In case of internal registry 
                     # mode, a new registry instance will be deployed within the cluster.
+    insecure: true #Use insecure docker registry
     url: "index.docker.io/username" # Domain name for internal\external registry. In case 
                                     # of internal registry, a new ingress resource will be 
                                     # created.
     username: "example" # Internal\external registry username
     password: "example" # Internal\external registry password
-  
-  hydrosphere:  
-    docker:
-      host: "harbor.hydrosphere.io/hydro-serving"
-      username: "developers"
-      password: "" # Registry password for accessing closed images
-      
+        
   persistence:
-    mode: minio # Persistence mode for services (one of s3, minio)
+    mode: local # Persistence mode for services (one of s3, minio)
     accessKey: ACCESSKEYEXAMPLE # accesskeyid for s3 or minio
     secretKey: SECRETKEYEXAMPLE # secretkeyid for s3 or minio
     region: eu-central-1 # Region of the bucket in case of S3 persistence mode.  
@@ -33,18 +29,6 @@ global:
     username: postgres # Postgresql username
     password: hydr0s3rving # Postgresql password
     database: hydro-serving # Postgresql database name 
-
-prometheus-am:
-  enabled: true
-  mail:
-    to: customer@example.io # Email address to send alarms to.
-    from: no-reply@hydrosphere.io # Email address of the sender.
-    smarthost: localhost:25  # SMTP relay host.
-    username: mailbot # SMTP relay username.
-    identity: mailbot # SMTP relay username identity.
-    password: password # SMTP relay password.
-
-  tolerations: []
   
 ui:
   public: true

--- a/helm/ui/templates/deployment.yaml
+++ b/helm/ui/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - name: AUTO_OD_GRPC_PORT
               value: "5001"
             - name: INGRESS_PATH
-              value: {{if .Values.global.ingress.enabled }}'//{{ .Values.global.ingress.frontendUrl }}{{ trimSuffix "/" .Values.global.ingress.path }}/'{{else}}'/'{{end}}
+              value: {{if .Values.global.ingress.enabled }}'//{{ .Values.global.ingress.host }}{{ .Values.global.ingress.path }}'{{else}}'{{ .Values.global.ingress.path }}'{{end}}
             {{- with .Values.env }}
 {{ toYaml . | indent 12 }}
             {{- end }}

--- a/helm/ui/templates/ingress.yaml
+++ b/helm/ui/templates/ingress.yaml
@@ -24,7 +24,7 @@ metadata:
     {{ end }}
 spec:
   rules:
-  - host: {{ .Values.global.ingress.frontendUrl }}
+  - host: {{ .Values.global.ingress.host }}
     http:
       paths:
       - backend:
@@ -33,7 +33,7 @@ spec:
         path: {{ template "ui.ingress-http-path" . }}
   tls:
   - hosts:
-    - {{ .Values.global.ingress.frontendUrl }}
+    - {{ .Values.global.ingress.host }}
     secretName: "{{ .Release.Name }}-ui-tls"
 ---
 {{- if .Values.global.ingress.enableGrpc }}
@@ -61,7 +61,7 @@ metadata:
     nginx.ingress.kubernetes.io/grpc-backend: "true"
 spec:
   rules:
-  - host: {{ .Values.global.ingress.frontendUrl }}
+  - host: {{ .Values.global.ingress.host }}
     http:
       paths:
         - path: "/tensorflow.serving."
@@ -74,7 +74,7 @@ spec:
             servicePort: grpc
   tls:
   - hosts:
-    - {{ .Values.global.ingress.frontendUrl }}
+    - {{ .Values.global.ingress.host }}
     secretName: "{{ .Release.Name }}-ui-grpc-tls"
 {{ end }}
 

--- a/helm/ui/values.yaml
+++ b/helm/ui/values.yaml
@@ -9,7 +9,7 @@ sonar:
 global:
   ingress:
     enabled: false
-    frontendUrl: ui.hydrosphere.io #Domain name to frontend
+    host: ui.hydrosphere.io #Domain name to frontend
     issuer: letsencrypt-prod #Cert-manager issuer name
     path: "/"
     enableGrpc: true


### PR DESCRIPTION
Added kube-registry-proxy to work without the inclusion of ingress
There are 4 installation scenarios: 
* registry is enabled, insecure:true and ingress is disabled, proxy-registry is added with node port 5000 and insecure-registry is configured as localhost:5000
* registry is disabled and insecure:true added insecure-registry as global.registry.url
* ingress enabled and registry enabled - removes insecure registry and requires a certificate for ingress + specify registry. url and frontendUrl
* ingress enabled and registry disabled - removes insecure registry and requires a specify frontendUrl and external registry.url

Default values is first