### PR TITLE
Remove DEFAULT_RUNTIME from auto-od

### DIFF
--- a/docker-compose/hydro-auto-od.service.template
+++ b/docker-compose/hydro-auto-od.service.template
@@ -12,7 +12,6 @@ services:
       - GRPC_PORT=5001
       - CLUSTER_ENDPOINT=http://managerui:8080
       - DEFAULT_TIMEOUT=120
-      - DEFAULT_RUNTIME=hydrosphere/serving-runtime-python-3.6
       - DEBUG=False
     depends_on:
       - mongodb


### PR DESCRIPTION
Removed from docker-compose since it's invalid and it's not used in helm configuration.

Fixes #349 